### PR TITLE
Add permision from caller workflow to enable job

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -29,5 +29,7 @@ jobs:
     uses: ./.github/workflows/_publish_torch_xla.yml
     needs: build-torch-xla
     secrets: inherit
+    permissions:
+      id-token: write
     with:
       artifact_name: ${{ needs.build-torch-xla.outputs.artifact_name }}


### PR DESCRIPTION
By default, reusable workflows do NOT get elevated permissions unless you explicitly grant them in the calling workflow. Adding permission to caller worflow.