### PR TITLE
(upstream merged) mul: remove opmath cast sequence

### DIFF
--- a/test/test_operations_hlo.py
+++ b/test/test_operations_hlo.py
@@ -67,6 +67,22 @@ class TestOperationsHlo(unittest.TestCase):
     hlo_text = torch_xla._XLAC._get_xla_tensors_hlo([b])
     assert 'u8' in hlo_text
 
+  def test_bfloat16_mul_not_upcast(self):
+    a = torch.rand(5, 5, dtype=torch.bfloat16).to('xla')
+    b = torch.rand(5, 5, dtype=torch.bfloat16).to('xla')
+    c = a * b
+    hlo_text = torch_xla._XLAC._get_xla_tensors_hlo([c])
+    # Check that the output is not upcasted to float32
+    assert 'f32' not in hlo_text
+
+  def test_bfloat16_float32_mul_upcast(self):
+    a = torch.rand(5, 5, dtype=torch.bfloat16).to('xla')
+    b = torch.rand(5, 5, dtype=torch.float32).to('xla')
+    c = a * b
+    hlo_text = torch_xla._XLAC._get_xla_tensors_hlo([c])
+    # Check that the output is upcasted to float32
+    assert 'f32' in hlo_text
+
 
 if __name__ == '__main__':
   torch.set_default_dtype(torch.float32)

--- a/torch_xla/csrc/aten_xla_type.cpp
+++ b/torch_xla/csrc/aten_xla_type.cpp
@@ -2396,7 +2396,6 @@ at::Tensor XLANativeFunctions::mul(const at::Tensor& self,
       .add_input(self)
       .add_input(other)
       .cast_inputs_to_common_dtype()
-      .use_opmathtype_for_compute()
       .run();
 }
 


### PR DESCRIPTION
Remove the explicit opmath-driven cast chain (bf16→f32→bf16, etc.) from `mul`. The op now executes in the dtype chosen by standard dtype promotion, without inserting unconditional upcast/downcast steps. But leave its functionality for future usage.

merged in upstream : https://github.com/pytorch/xla/pull/9663