### PR TITLE
Smuggle Logical Buffer IDs  through BufferFromHostBuffer dims

### DIFF
--- a/torch_xla/csrc/runtime/pjrt_computation_client.cpp
+++ b/torch_xla/csrc/runtime/pjrt_computation_client.cpp
@@ -275,11 +275,19 @@ std::vector<ComputationClient::DataPtr> PjRtComputationClient::TransferToDevice(
 
     total_size += xla::ShapeUtil::ByteSizeOf(tensor->shape());
 
+    auto dims = tensor->dimensions();
+    auto strides = tensor->byte_strides();
+    int64_t source_id = tensor->source_id();
+    if (source_id >= 0) {
+      dims.push_back(source_id);
+      strides.push_back(0);
+    }
+
     std::shared_ptr<xla::PjRtBuffer> buffer =
         std::move(client_
                       ->BufferFromHostBuffer(
                           tensor->data(), tensor->primitive_type(),
-                          tensor->dimensions(), tensor->byte_strides(),
+                          dims, strides,
                           xla::PjRtClient::HostBufferSemantics::
                               kImmutableUntilTransferCompletes,
                           [tensor]() { /* frees tensor */ },

--- a/torch_xla/csrc/runtime/pjrt_computation_client.cpp
+++ b/torch_xla/csrc/runtime/pjrt_computation_client.cpp
@@ -280,7 +280,7 @@ std::vector<ComputationClient::DataPtr> PjRtComputationClient::TransferToDevice(
     int64_t source_id = tensor->source_id();
     if (source_id >= 0) {
       dims.push_back(source_id);
-      strides.push_back(0);
+      strides.push_back(-1);
     }
 
     std::shared_ptr<xla::PjRtBuffer> buffer =

--- a/torch_xla/csrc/runtime/tensor_source.h
+++ b/torch_xla/csrc/runtime/tensor_source.h
@@ -4,6 +4,7 @@
 #include <ATen/Tensor.h>
 #include <torch/csrc/lazy/core/metrics.h>
 
+#include <atomic>
 #include <string>
 #include <utility>
 #include <vector>
@@ -18,6 +19,11 @@
 namespace torch_xla {
 namespace runtime {
 
+inline int64_t NextSourceId() {
+  static std::atomic<int64_t> counter{0};
+  return counter.fetch_add(1, std::memory_order_relaxed);
+}
+
 // Owns a contiguous block of data with the shape and layout matching `shape()`.
 class TensorSource {
  public:
@@ -28,6 +34,11 @@ class TensorSource {
   virtual const xla::Shape& shape() const = 0;
 
   const std::string& device() const { return device_; }
+
+  // Identifies the logical tensor this shard originated from. All shards
+  // produced from the same source tensor share the same source_id.
+  int64_t source_id() const { return source_id_; }
+  void set_source_id(int64_t id) { source_id_ = id; }
 
   virtual std::vector<int64_t> byte_strides() const {
     std::vector<int64_t> byte_strides(shape().dimensions_size());
@@ -47,6 +58,7 @@ class TensorSource {
 
  private:
   std::string device_;
+  int64_t source_id_ = -1;
 };
 
 class AtenSource : public TensorSource {

--- a/torch_xla/csrc/xla_sharding_util.cpp
+++ b/torch_xla/csrc/xla_sharding_util.cpp
@@ -685,12 +685,15 @@ runtime::ComputationClient::DataPtr ShardingUtil::CreateShardedData(
     global_shape = sharding_spec->shape;
     sharding = sharding_spec->sharding;
   }
+  int64_t source_id = runtime::NextSourceId();
   for (int64_t j = 0; j < devices.size(); ++j) {
     auto shard_device = ParseDeviceString(devices[j]);
     auto shard_shape =
         CreateComputationShapeFromTensor(local_shards[j], &shard_device);
-    source_tensors.push_back(std::make_shared<runtime::AtenSource>(
-        local_shards[j], shard_shape, devices[j]));
+    auto source = std::make_shared<runtime::AtenSource>(
+        local_shards[j], shard_shape, devices[j]);
+    source->set_source_id(source_id);
+    source_tensors.push_back(source);
   }
   return runtime::GetComputationClientOrDie()->TransferShardsToDevice(
       source_tensors, GetVirtualDevice().toString(), global_shape, sharding);


### PR DESCRIPTION
- Logical buffer IDs are generated in SPMD mode `ShardingUtil::CreateShardedData`, which runs once per logical tensor and attaches a monotonically increasing integer logical tensor ID to AtenSource. So, all shards or replicas of a tensor will share a logical tensor ID
- Use BufferFromHostBuffer dims/strides args as a sidechannel to pass the logical tensor id
  - Last rank dims value is the logical tensor ID
  - Last rank byte_strides value is -1 as a sentinel (which has a valid use, so it's not a guarantee that this mechanism is active)

This is a breaking change and a bit of a hack to forward some data from torch_xla into our PJRT client since we cannot change this API surface without modifying openxla/xla.     