### PR TITLE
Update torch-xla wheel to build uisng torch 2.11.0

### DIFF
--- a/.github/workflows/_build_torch_xla_release.yml
+++ b/.github/workflows/_build_torch_xla_release.yml
@@ -7,10 +7,10 @@ on:
         required: true
         type: string
       torch_version:
-        description: 'Torch version to build (default: 2.10.0)'
+        description: 'Torch version to build (default: 2.11.0)'
         required: false
         type: string
-        default: '2.10.0'
+        default: '2.11.0'
       xla_branch:
         description: 'PyTorch-XLA branch to build (default: master)'
         required: false
@@ -27,10 +27,10 @@ on:
         required: true
         type: string
       torch_version:
-        description: 'Torch version to build (default: 2.10.0)'
+        description: 'Torch version to build (default: 2.11.0)'
         required: false
         type: string
-        default: '2.10.0'
+        default: '2.11.0'
       xla_branch:
         description: 'PyTorch-XLA branch to build (default: master)'
         required: false

--- a/torch_xla/csrc/BUILD
+++ b/torch_xla/csrc/BUILD
@@ -262,7 +262,10 @@ cc_library(
 
 ptxla_cc_library(
     name = "init_python_bindings",
-    srcs = ["init_python_bindings.cpp"],
+    srcs = [
+        "init_python_bindings.cpp",
+        "jit_type_infer_shim.cpp",
+    ],
     deps = [
         ":device",
         ":dtype",

--- a/torch_xla/csrc/jit_type_infer_shim.cpp
+++ b/torch_xla/csrc/jit_type_infer_shim.cpp
@@ -1,0 +1,19 @@
+#include <torch/csrc/jit/python/pybind_utils.h>
+
+#ifdef USE_DISTRIBUTED
+#include <torch/csrc/distributed/c10d/ProcessGroup.hpp>
+#endif
+
+namespace torch::jit {
+
+std::optional<InferredType> detail::_tryToInferTypeImpl(py::handle input) {
+#ifdef USE_DISTRIBUTED
+  if (py::isinstance<c10d::ProcessGroup>(input)) {
+    return InferredType(CapsuleType::get());
+  }
+#endif
+
+  return std::nullopt;
+}
+
+} // namespace torch::jit


### PR DESCRIPTION
Uplifting torch==2.11.0 which requires torch-xla wheel built using torch==2.11.0 for compatibility.