### PR TITLE
[runtime] Bypass ReplicateShardedData in TransferFromDevice

### DIFF
--- a/torch_xla/csrc/runtime/pjrt_computation_client.cpp
+++ b/torch_xla/csrc/runtime/pjrt_computation_client.cpp
@@ -509,6 +509,19 @@ std::shared_ptr<xla::PjRtBuffer> PjRtComputationClient::GetPjRtBuffer(
   }
 }
 
+std::vector<int64_t> ComputeShardOffset(int64_t shard_idx, absl::Span<const int64_t> tile_dim, absl::Span<const int64_t> shard_dims){
+  // 
+  int64_t rank = tile_dim.size();
+  std::vector<int64_t> offset(rank, 0);
+  int64_t remainder = shard_idx;
+  for(int j = rank-1; j>=0; --j){
+    int64_t n_j = remainder % tile_dim[j];
+    remainder /= tile_dim[j];
+    offset[j] = n_j * shard_dims[j];
+  }
+  return offset;
+}
+
 std::vector<xla::Literal> PjRtComputationClient::TransferFromDevice(
     absl::Span<const DataPtr> handles) {
   metrics::TimedSection timed(TransferFromDeviceMetric());
@@ -519,21 +532,57 @@ std::vector<xla::Literal> PjRtComputationClient::TransferFromDevice(
   std::vector<xla::Literal> literals;
   literals.reserve(handles.size());
   int64_t total_size = 0;
+ 
   for (auto handle : handles) {
-    // Use XLA replication to reassemble the sharded data. If input handle
-    // is not sharded, then it is a no-op.
-    std::shared_ptr<PjRtData> pjrt_data = ReplicateShardedData(handle);
-    XLA_CHECK(pjrt_data) << "PjRt_data is null in " << __FUNCTION__;
-    XLA_CHECK(pjrt_data->buffer != nullptr)
-        << "PjRt buffer is null in " << __FUNCTION__;
+    if (auto sharded = std::dynamic_pointer_cast<PjRtShardedData>(handle); sharded && sharded->GetSharding().type() == xla::OpSharding::OTHER){ // got sharded and is OTHER sharding
+      std::vector<xla::PjRtFuture<>> futures_local_shards;
+      futures_local_shards.reserve(sharded->shards.size());
+      std::vector<xla::Literal> literals_local_shards;
+      literals_local_shards.reserve(sharded->shards.size());
 
-    xla::Literal& literal =
-        literals.emplace_back(host_output_shape(pjrt_data->buffer.get()));
-    futures.push_back(pjrt_data->buffer->ToLiteral(&literal));
+      for (auto& shard : sharded->shards){ // pull each local shard to the host in parallel
+        xla::Literal& literal =
+            literals_local_shards.emplace_back(host_output_shape(shard->buffer.get()));
+        futures_local_shards.push_back(shard->buffer->ToLiteral(&literal));
+      }
 
-    total_size += literal.size_bytes();
+      for (auto& future : futures_local_shards){ // wait for all local shards to be transferred to the host
+        absl::Status status = future.Await();
+        XLA_CHECK_OK(status) << "Failed to await future from buffer to literal in"
+                            << __FUNCTION__;
+      }
+
+      xla::Literal& global_literal = // global literal to store the stitched result
+          literals.emplace_back(xla::ShapeUtil::DeviceShapeToHostShape(sharded->shape()));
+      
+      auto tile_dim = sharded->GetSharding().tile_assignment_dimensions(); // remember to account for replicate_on_last_dim, without it this is wrong if there is replicate
+      auto rank = tile_dim.size();
+
+      for (int64_t i = 0; i < literals_local_shards.size(); ++i){
+        absl::Status status = global_literal.CopySliceFrom( /*src_literal*/ literals_local_shards[i], 
+                                                            /*src_base*/ std::vector<int64_t>(rank, 0), // just {0...0}
+                                                            /*dest_base*/ ComputeShardOffset(i, tile_dim, literals_local_shards[i].shape().dimensions()),
+                                                            /*copy_size*/ literals_local_shards[i].shape().dimensions());
+        XLA_CHECK_OK(status) << "Failed to copy slice from local shard to global literal in"
+                            << __FUNCTION__;
+      }
+      total_size += global_literal.size_bytes();
+    } 
+    else {
+      // fallback to legacy path
+      std::shared_ptr<PjRtData> pjrt_data = ReplicateShardedData(handle);
+      XLA_CHECK(pjrt_data) << "PjRt_data is null in " << __FUNCTION__;
+      XLA_CHECK(pjrt_data->buffer != nullptr)
+          << "PjRt buffer is null in " << __FUNCTION__;
+      xla::Literal& literal =
+          literals.emplace_back(host_output_shape(pjrt_data->buffer.get()));
+      futures.push_back(pjrt_data->buffer->ToLiteral(&literal));
+
+      total_size += literal.size_bytes();
+    }
   }
-  for (auto& future : futures) {
+  
+  for (auto& future : futures) { // just waiting for all handles to be transferred to the host
     absl::Status status = future.Await();
     XLA_CHECK_OK(status) << "Failed to await future from buffer to literal in"
                          << __FUNCTION__;

--- a/torch_xla/csrc/runtime/pjrt_computation_client.cpp
+++ b/torch_xla/csrc/runtime/pjrt_computation_client.cpp
@@ -536,80 +536,114 @@ std::vector<int64_t> ComputeTileAssignmentDevices(const xla::OpSharding& shardin
                               sharding.tile_assignment_devices().end());
 }
 
+struct TilePosition {
+  int64_t start;
+  int64_t size;
+  std::vector<int64_t> tile_dim;
+};
+
 std::vector<xla::Literal> PjRtComputationClient::TransferFromDevice(
     absl::Span<const DataPtr> handles) {
   metrics::TimedSection timed(TransferFromDeviceMetric());
   tsl::profiler::TraceMe activity("PjRtComputationClient::TransferFromDevice",
                                   tsl::profiler::TraceMeLevel::kInfo);
+  
+  size_t total = 0;
+  for (const auto& handle : handles) {
+    if (auto sharded = std::dynamic_pointer_cast<PjRtShardedData>(handle);
+        sharded && sharded->GetSharding().type() == xla::OpSharding::OTHER) {
+      total += sharded->shards.size();
+    } else {
+      total += 1;
+    }
+  }
+
   std::vector<xla::PjRtFuture<>> futures;
-  futures.reserve(handles.size());
+  futures.reserve(total);
+  std::vector<xla::Literal> global_literals;
+  global_literals.reserve(total);
   std::vector<xla::Literal> literals;
   literals.reserve(handles.size());
+  std::vector<std::optional<TilePosition>> tile_positions;
+  tile_positions.reserve(handles.size());
   int64_t total_size = 0;
  
+  int64_t start_index = 0;
   for (auto handle : handles) {
-    if (auto sharded = std::dynamic_pointer_cast<PjRtShardedData>(handle); sharded && sharded->GetSharding().type() == xla::OpSharding::OTHER){ // got sharded and is OTHER sharding
-      std::vector<xla::PjRtFuture<>> futures_local_shards;
-      futures_local_shards.reserve(sharded->shards.size());
-      std::vector<xla::Literal> literals_local_shards;
-      literals_local_shards.reserve(sharded->shards.size());
-
-      for (auto& shard : sharded->shards){ // pull each local shard to the host in parallel
+    if (auto sharded = std::dynamic_pointer_cast<PjRtShardedData>(handle)){
+      if (sharded->GetSharding().type() == xla::OpSharding::REPLICATED){
+        // just take the first shard
+        auto& shard = sharded->shards[0];
         xla::Literal& literal =
-            literals_local_shards.emplace_back(host_output_shape(shard->buffer.get()));
-        futures_local_shards.push_back(shard->buffer->ToLiteral(&literal));
+            literals.emplace_back(host_output_shape(shard->buffer.get()));
+        futures.push_back(shard->buffer->ToLiteral(&literal));
+        tile_positions.emplace_back(std::nullopt);
+        ++start_index;
+        total_size += literal.size_bytes();
       }
+      else if (sharded->GetSharding().type() == xla::OpSharding::OTHER){
+        // other sharding
+        auto op_sharding = sharded->GetSharding();
+        auto replicate_on_last_dim = op_sharding.replicate_on_last_tile_dim();
+        auto tile_dim = op_sharding.tile_assignment_dimensions();
+        int64_t replicated_dim = 1;
+        if (replicate_on_last_dim){
+          replicated_dim = tile_dim.Get(tile_dim.size() - 1);
+          tile_dim.RemoveLast();
+        }
+        auto rank = tile_dim.size();
+        auto tile_devices = ComputeTileAssignmentDevices(op_sharding);
+        auto num_shards = sharded->shards.size();
 
-      for (auto& future : futures_local_shards){ // wait for all local shards to be transferred to the host
-        absl::Status status = future.Await();
-        XLA_CHECK_OK(status) << "Failed to await future from buffer to literal in"
-                            << __FUNCTION__;
-      }
+        for (int64_t i = 0; i < num_shards; i+=replicated_dim){
+          auto tile_pos = tile_devices[i];
+          xla::Literal& literal = global_literals.emplace_back(host_output_shape(sharded->shards[tile_pos]->buffer.get()));
+          futures.push_back(sharded->shards[tile_pos]->buffer->ToLiteral(&literal));
+        }
+        tile_positions.emplace_back(TilePosition{start_index, num_shards/replicated_dim, std::vector<int64_t>(tile_dim.begin(), tile_dim.end())});
+        start_index += num_shards/replicated_dim;
 
-      xla::Literal& global_literal = // global literal to store the stitched result
-          literals.emplace_back(xla::ShapeUtil::DeviceShapeToHostShape(sharded->shape()));
-      
-      auto op_sharding = sharded->GetSharding();
-      auto replicate_on_last_dim = op_sharding.replicate_on_last_tile_dim();
-      auto tile_dim = op_sharding.tile_assignment_dimensions();
-      int64_t replicated_dim = 1;
-      if (replicate_on_last_dim){
-        replicated_dim = tile_dim.Get(tile_dim.size() - 1);
-        tile_dim.RemoveLast();
+        xla::Literal& literal = // global literal to store the stitched result
+            literals.emplace_back(xla::ShapeUtil::DeviceShapeToHostShape(sharded->shape()));
+      } 
+      else {
+        XLA_ERROR() << "Sharding type not supported, got " << sharded->GetSharding().type();
       }
-      auto rank = tile_dim.size();
-      auto tile_devices = ComputeTileAssignmentDevices(op_sharding);
-      
-      for (int64_t i = 0; i < literals_local_shards.size()/replicated_dim; ++i){
-        auto tile_pos = tile_devices[i*replicated_dim];
-        absl::Status status = global_literal.CopySliceFrom( /*src_literal*/ literals_local_shards[tile_pos], 
-                                                            /*src_base*/ std::vector<int64_t>(rank, 0), // just {0...0}
-                                                            /*dest_base*/ ComputeShardOffset(i, tile_dim, literals_local_shards[tile_pos].shape().dimensions()),
-                                                            /*copy_size*/ literals_local_shards[tile_pos].shape().dimensions());
-        XLA_CHECK_OK(status) << "Failed to copy slice from local shard to global literal in"
-                            << __FUNCTION__;
-      }
-      total_size += global_literal.size_bytes();
-    } 
-    else {
-      // fallback to legacy path
-      std::shared_ptr<PjRtData> pjrt_data = ReplicateShardedData(handle);
-      XLA_CHECK(pjrt_data) << "PjRt_data is null in " << __FUNCTION__;
-      XLA_CHECK(pjrt_data->buffer != nullptr)
-          << "PjRt buffer is null in " << __FUNCTION__;
+    }
+    else if(auto unsharded = std::dynamic_pointer_cast<PjRtData>(handle)){
+      // unsharded
       xla::Literal& literal =
-          literals.emplace_back(host_output_shape(pjrt_data->buffer.get()));
-      futures.push_back(pjrt_data->buffer->ToLiteral(&literal));
-
+          literals.emplace_back(host_output_shape(unsharded->buffer.get()));
+      futures.push_back(unsharded->buffer->ToLiteral(&literal));
+      tile_positions.emplace_back(std::nullopt);
+      ++start_index;
       total_size += literal.size_bytes();
+    }
+    else {
+      XLA_ERROR() << "Data handle is null in " << __FUNCTION__;
     }
   }
   
-  for (auto& future : futures) { // just waiting for all handles to be transferred to the host
+  for (auto& future : futures) {
     absl::Status status = future.Await();
     XLA_CHECK_OK(status) << "Failed to await future from buffer to literal in"
                          << __FUNCTION__;
   }
+
+  for (int64_t i = 0; i < tile_positions.size(); ++i){
+    if (!tile_positions[i]) continue; // unsharded
+    auto& tp = tile_positions[i].value();
+    for (int64_t j = tp.start; j < tp.start + tp.size; ++j){
+      absl::Status status = literals[i].CopySliceFrom(  /*src_literal*/ global_literals[j], 
+                                                        /*src_base*/ std::vector<int64_t>(tp.tile_dim.size(), 0), // just {0...0}
+                                                        /*dest_base*/ ComputeShardOffset(j - tp.start, tp.tile_dim, global_literals[j].shape().dimensions()),
+                                                        /*copy_size*/ global_literals[j].shape().dimensions());
+      XLA_CHECK_OK(status) << "Failed to copy slice from local shard to global literal in"
+                          << __FUNCTION__;
+    }
+    total_size += literals[i].size_bytes();
+  }
+
   InboundDataMetric()->AddSample(total_size);
 
   return literals;

--- a/torch_xla/csrc/runtime/pjrt_computation_client.cpp
+++ b/torch_xla/csrc/runtime/pjrt_computation_client.cpp
@@ -93,6 +93,41 @@ torch::lazy::hash_t hash_comp_env(
   return hash;
 }
 
+std::vector<int64_t> ComputeShardOffset(int64_t shard_idx,
+                                        absl::Span<const int64_t> tile_dim,
+                                        absl::Span<const int64_t> shard_dims) {
+  int64_t rank = tile_dim.size();
+  std::vector<int64_t> offset(rank, 0);
+  int64_t remainder = shard_idx;
+  for (int64_t j = rank - 1; j >= 0; --j) {
+    int64_t n_j = remainder % tile_dim[j];
+    remainder /= tile_dim[j];
+    offset[j] = n_j * shard_dims[j];
+  }
+  return offset;
+}
+
+std::vector<int64_t> ComputeTileAssignmentDevices(
+    const xla::OpSharding& sharding) {
+  if (!sharding.iota_reshape_dims().empty()) {
+    // V2 iota form (common case)
+    xla::TileAssignment tile_assignment(sharding.tile_assignment_dimensions(),
+                                        sharding.iota_reshape_dims(),
+                                        sharding.iota_transpose_perm());
+    return std::vector<int64_t>(tile_assignment.array().begin(),
+                                tile_assignment.array().end());
+  }
+  // V1 explicit form
+  return std::vector<int64_t>(sharding.tile_assignment_devices().begin(),
+                              sharding.tile_assignment_devices().end());
+}
+
+struct TilePosition {
+  int64_t start;
+  int64_t size;
+  std::vector<int64_t> tile_dim;
+};
+
 }  // namespace
 
 std::string PjRtComputationClient::PjRtDeviceToString(
@@ -509,119 +544,80 @@ std::shared_ptr<xla::PjRtBuffer> PjRtComputationClient::GetPjRtBuffer(
   }
 }
 
-std::vector<int64_t> ComputeShardOffset(int64_t shard_idx, absl::Span<const int64_t> tile_dim, absl::Span<const int64_t> shard_dims){
-  // Compute the offset of the shard in the global tensor
-  int64_t rank = tile_dim.size();
-  std::vector<int64_t> offset(rank, 0);
-  int64_t remainder = shard_idx;
-  for(int j = rank-1; j>=0; --j){
-    int64_t n_j = remainder % tile_dim[j];
-    remainder /= tile_dim[j];
-    offset[j] = n_j * shard_dims[j];
-  }
-  return offset;
-}
-
-std::vector<int64_t> ComputeTileAssignmentDevices(const xla::OpSharding& sharding){
-  if (!sharding.iota_reshape_dims().empty()) {
-    // V2 iota form (common case)
-    xla::TileAssignment tile_assignment(
-        sharding.tile_assignment_dimensions(),
-        sharding.iota_reshape_dims(),
-        sharding.iota_transpose_perm());
-    return std::vector<int64_t>(tile_assignment.array().begin(), tile_assignment.array().end());
-  }
-  // V1 explicit form
-  return std::vector<int64_t>(sharding.tile_assignment_devices().begin(),
-                              sharding.tile_assignment_devices().end());
-}
-
-// struct for reconstructing the global tensor from local shards
-// from global_literals[start] with size tiles
-struct TilePosition {
-  int64_t start;
-  int64_t size;
-  std::vector<int64_t> tile_dim;
-};
-
 std::vector<xla::Literal> PjRtComputationClient::TransferFromDevice(
     absl::Span<const DataPtr> handles) {
   metrics::TimedSection timed(TransferFromDeviceMetric());
   tsl::profiler::TraceMe activity("PjRtComputationClient::TransferFromDevice",
                                   tsl::profiler::TraceMeLevel::kInfo);
   
-  size_t total = 0;
+  size_t total_transfers = 0;
   for (const auto& handle : handles) {
     if (auto sharded = std::dynamic_pointer_cast<PjRtShardedData>(handle);
         sharded && sharded->GetSharding().type() == xla::OpSharding::OTHER) {
-      total += sharded->shards.size();
+      total_transfers += sharded->shards.size();
     } else {
-      total += 1;
+      total_transfers += 1;
     }
   }
 
   std::vector<xla::PjRtFuture<>> futures;
-  futures.reserve(total);
+  futures.reserve(total_transfers);
   std::vector<xla::Literal> global_literals;
-  global_literals.reserve(total);
+  global_literals.reserve(total_transfers);
   std::vector<xla::Literal> literals;
   literals.reserve(handles.size());
   std::vector<std::optional<TilePosition>> tile_positions;
   tile_positions.reserve(handles.size());
   int64_t total_size = 0;
- 
-  int64_t start_index = 0;
-  for (auto handle : handles) {
-    if (auto sharded = std::dynamic_pointer_cast<PjRtShardedData>(handle)){
-      if (sharded->GetSharding().type() == xla::OpSharding::REPLICATED){
+
+  for (const auto& handle : handles) {
+    if (auto sharded = std::dynamic_pointer_cast<PjRtShardedData>(handle)) {
+      if (sharded->GetSharding().type() == xla::OpSharding::REPLICATED) {
         // just take the first shard
         auto& shard = sharded->shards[0];
         xla::Literal& literal =
             literals.emplace_back(host_output_shape(shard->buffer.get()));
         futures.push_back(shard->buffer->ToLiteral(&literal));
         tile_positions.emplace_back(std::nullopt);
-        ++start_index;
         total_size += literal.size_bytes();
-      }
-      else if (sharded->GetSharding().type() == xla::OpSharding::OTHER){
-        // other sharding
+      } else if (sharded->GetSharding().type() == xla::OpSharding::OTHER) {
         auto op_sharding = sharded->GetSharding();
         auto replicate_on_last_dim = op_sharding.replicate_on_last_tile_dim();
         auto tile_dim = op_sharding.tile_assignment_dimensions();
         int64_t replicated_dim = 1;
-        if (replicate_on_last_dim){
+        if (replicate_on_last_dim) {
           replicated_dim = tile_dim.Get(tile_dim.size() - 1);
           tile_dim.RemoveLast();
         }
-        auto rank = tile_dim.size();
         auto tile_devices = ComputeTileAssignmentDevices(op_sharding);
         auto num_shards = sharded->shards.size();
 
-        for (int64_t i = 0; i < num_shards; i+=replicated_dim){
+        int64_t start = global_literals.size();
+        for (int64_t i = 0; i < num_shards; i += replicated_dim) {
           auto tile_pos = tile_devices[i];
-          xla::Literal& literal = global_literals.emplace_back(host_output_shape(sharded->shards[tile_pos]->buffer.get()));
-          futures.push_back(sharded->shards[tile_pos]->buffer->ToLiteral(&literal));
+          xla::Literal& literal = global_literals.emplace_back(
+              host_output_shape(sharded->shards[tile_pos]->buffer.get()));
+          futures.push_back(
+              sharded->shards[tile_pos]->buffer->ToLiteral(&literal));
         }
-        tile_positions.emplace_back(TilePosition{start_index, num_shards/replicated_dim, std::vector<int64_t>(tile_dim.begin(), tile_dim.end())});
-        start_index += num_shards/replicated_dim;
+        tile_positions.emplace_back(TilePosition{
+            start, static_cast<int64_t>(num_shards / replicated_dim),
+            std::vector<int64_t>(tile_dim.begin(), tile_dim.end())});
 
-        xla::Literal& literal = // global literal to store the stitched result
-            literals.emplace_back(xla::ShapeUtil::DeviceShapeToHostShape(sharded->shape()));
-      } 
-      else {
-        XLA_ERROR() << "Sharding type not supported, got " << sharded->GetSharding().type();
+        // global literal to store the stitched result
+        literals.emplace_back(
+            xla::ShapeUtil::DeviceShapeToHostShape(sharded->shape()));
+      } else {
+        XLA_ERROR() << "Sharding type not supported, got "
+                    << sharded->GetSharding().type();
       }
-    }
-    else if(auto unsharded = std::dynamic_pointer_cast<PjRtData>(handle)){
-      // unsharded
+    } else if (auto unsharded = std::dynamic_pointer_cast<PjRtData>(handle)) {
       xla::Literal& literal =
           literals.emplace_back(host_output_shape(unsharded->buffer.get()));
       futures.push_back(unsharded->buffer->ToLiteral(&literal));
       tile_positions.emplace_back(std::nullopt);
-      ++start_index;
       total_size += literal.size_bytes();
-    }
-    else {
+    } else {
       XLA_ERROR() << "Data handle is null in " << __FUNCTION__;
     }
   }

--- a/torch_xla/csrc/runtime/pjrt_computation_client.cpp
+++ b/torch_xla/csrc/runtime/pjrt_computation_client.cpp
@@ -522,6 +522,20 @@ std::vector<int64_t> ComputeShardOffset(int64_t shard_idx, absl::Span<const int6
   return offset;
 }
 
+std::vector<int64_t> ComputeTileAssignmentDevices(const xla::OpSharding& sharding){
+  if (!sharding.iota_reshape_dims().empty()) {
+    // V2 iota form
+    xla::TileAssignment tile_assignment(
+        sharding.tile_assignment_dimensions(),
+        sharding.iota_reshape_dims(),
+        sharding.iota_transpose_perm());
+    return std::vector<int64_t>(tile_assignment.array().begin(), tile_assignment.array().end());
+  }
+  // V1 explicit form
+  return std::vector<int64_t>(sharding.tile_assignment_devices().begin(),
+                              sharding.tile_assignment_devices().end());
+}
+
 std::vector<xla::Literal> PjRtComputationClient::TransferFromDevice(
     absl::Span<const DataPtr> handles) {
   metrics::TimedSection timed(TransferFromDeviceMetric());
@@ -555,14 +569,16 @@ std::vector<xla::Literal> PjRtComputationClient::TransferFromDevice(
       xla::Literal& global_literal = // global literal to store the stitched result
           literals.emplace_back(xla::ShapeUtil::DeviceShapeToHostShape(sharded->shape()));
       
-      auto tile_dim = sharded->GetSharding().tile_assignment_dimensions(); // remember to account for replicate_on_last_dim, without it this is wrong if there is replicate
+      auto op_sharding = sharded->GetSharding();
+      auto tile_dim = op_sharding.tile_assignment_dimensions(); // remember to account for replicate_on_last_dim, without it this is wrong if there is replicate
       auto rank = tile_dim.size();
-
+      auto tile_devices = ComputeTileAssignmentDevices(op_sharding);
+      
       for (int64_t i = 0; i < literals_local_shards.size(); ++i){
-        absl::Status status = global_literal.CopySliceFrom( /*src_literal*/ literals_local_shards[i], 
+        absl::Status status = global_literal.CopySliceFrom( /*src_literal*/ literals_local_shards[tile_devices[i]], 
                                                             /*src_base*/ std::vector<int64_t>(rank, 0), // just {0...0}
-                                                            /*dest_base*/ ComputeShardOffset(i, tile_dim, literals_local_shards[i].shape().dimensions()),
-                                                            /*copy_size*/ literals_local_shards[i].shape().dimensions());
+                                                            /*dest_base*/ ComputeShardOffset(i, tile_dim, literals_local_shards[tile_devices[i]].shape().dimensions()),
+                                                            /*copy_size*/ literals_local_shards[tile_devices[i]].shape().dimensions());
         XLA_CHECK_OK(status) << "Failed to copy slice from local shard to global literal in"
                             << __FUNCTION__;
       }

--- a/torch_xla/csrc/runtime/pjrt_computation_client.cpp
+++ b/torch_xla/csrc/runtime/pjrt_computation_client.cpp
@@ -524,7 +524,7 @@ std::vector<int64_t> ComputeShardOffset(int64_t shard_idx, absl::Span<const int6
 
 std::vector<int64_t> ComputeTileAssignmentDevices(const xla::OpSharding& sharding){
   if (!sharding.iota_reshape_dims().empty()) {
-    // V2 iota form
+    // V2 iota form (common case)
     xla::TileAssignment tile_assignment(
         sharding.tile_assignment_dimensions(),
         sharding.iota_reshape_dims(),
@@ -570,15 +570,22 @@ std::vector<xla::Literal> PjRtComputationClient::TransferFromDevice(
           literals.emplace_back(xla::ShapeUtil::DeviceShapeToHostShape(sharded->shape()));
       
       auto op_sharding = sharded->GetSharding();
-      auto tile_dim = op_sharding.tile_assignment_dimensions(); // remember to account for replicate_on_last_dim, without it this is wrong if there is replicate
+      auto replicate_on_last_dim = op_sharding.replicate_on_last_tile_dim();
+      auto tile_dim = op_sharding.tile_assignment_dimensions();
+      int64_t replicated_dim = 1;
+      if (replicate_on_last_dim){
+        replicated_dim = tile_dim.Get(tile_dim.size() - 1);
+        tile_dim.RemoveLast();
+      }
       auto rank = tile_dim.size();
       auto tile_devices = ComputeTileAssignmentDevices(op_sharding);
       
-      for (int64_t i = 0; i < literals_local_shards.size(); ++i){
-        absl::Status status = global_literal.CopySliceFrom( /*src_literal*/ literals_local_shards[tile_devices[i]], 
+      for (int64_t i = 0; i < literals_local_shards.size()/replicated_dim; ++i){
+        auto tile_pos = tile_devices[i*replicated_dim];
+        absl::Status status = global_literal.CopySliceFrom( /*src_literal*/ literals_local_shards[tile_pos], 
                                                             /*src_base*/ std::vector<int64_t>(rank, 0), // just {0...0}
-                                                            /*dest_base*/ ComputeShardOffset(i, tile_dim, literals_local_shards[tile_devices[i]].shape().dimensions()),
-                                                            /*copy_size*/ literals_local_shards[tile_devices[i]].shape().dimensions());
+                                                            /*dest_base*/ ComputeShardOffset(i, tile_dim, literals_local_shards[tile_pos].shape().dimensions()),
+                                                            /*copy_size*/ literals_local_shards[tile_pos].shape().dimensions());
         XLA_CHECK_OK(status) << "Failed to copy slice from local shard to global literal in"
                             << __FUNCTION__;
       }

--- a/torch_xla/csrc/runtime/pjrt_computation_client.cpp
+++ b/torch_xla/csrc/runtime/pjrt_computation_client.cpp
@@ -510,7 +510,7 @@ std::shared_ptr<xla::PjRtBuffer> PjRtComputationClient::GetPjRtBuffer(
 }
 
 std::vector<int64_t> ComputeShardOffset(int64_t shard_idx, absl::Span<const int64_t> tile_dim, absl::Span<const int64_t> shard_dims){
-  // 
+  // Compute the offset of the shard in the global tensor
   int64_t rank = tile_dim.size();
   std::vector<int64_t> offset(rank, 0);
   int64_t remainder = shard_idx;
@@ -536,6 +536,8 @@ std::vector<int64_t> ComputeTileAssignmentDevices(const xla::OpSharding& shardin
                               sharding.tile_assignment_devices().end());
 }
 
+// struct for reconstructing the global tensor from local shards
+// from global_literals[start] with size tiles
 struct TilePosition {
   int64_t start;
   int64_t size;

--- a/torch_xla/csrc/runtime/pjrt_computation_client.cpp
+++ b/torch_xla/csrc/runtime/pjrt_computation_client.cpp
@@ -122,6 +122,18 @@ std::vector<int64_t> ComputeTileAssignmentDevices(
                               sharding.tile_assignment_devices().end());
 }
 
+// Records the layout of one OTHER-sharded handle's per-shard literals inside
+// the flat `global_literals` pool. `start` and `size` describe the contiguous
+// range `[start, start + size)` of `global_literals` that belongs to the
+// handle; `tile_dim` is an owning copy of the sharding's tile dimensions
+// (replicate_on_last_tile_dim already stripped) used by the stitch pass.
+//
+// The owning `std::vector<std::optional<TilePosition>>` is indexed in
+// lock-step with the function's `literals` output vector: each input handle
+// contributes exactly one entry, with std::nullopt for handles that don't
+// need stitching (REPLICATED / unsharded). Anyone editing TransferFromDevice
+// must preserve that one-entry-per-handle invariant or the stitch pass will
+// write to the wrong literal.
 struct TilePosition {
   int64_t start;
   int64_t size;
@@ -579,7 +591,6 @@ std::vector<xla::Literal> PjRtComputationClient::TransferFromDevice(
             literals.emplace_back(host_output_shape(shard->buffer.get()));
         futures.push_back(shard->buffer->ToLiteral(&literal));
         tile_positions.emplace_back(std::nullopt);
-        total_size += literal.size_bytes();
       } else if (sharded->GetSharding().type() == xla::OpSharding::OTHER) {
         auto op_sharding = sharded->GetSharding();
         auto replicate_on_last_dim = op_sharding.replicate_on_last_tile_dim();
@@ -616,10 +627,10 @@ std::vector<xla::Literal> PjRtComputationClient::TransferFromDevice(
           literals.emplace_back(host_output_shape(unsharded->buffer.get()));
       futures.push_back(unsharded->buffer->ToLiteral(&literal));
       tile_positions.emplace_back(std::nullopt);
-      total_size += literal.size_bytes();
     } else {
       XLA_ERROR() << "Data handle is null in " << __FUNCTION__;
     }
+    total_size += literals.back().size_bytes();
   }
   
   for (auto& future : futures) {
@@ -639,7 +650,6 @@ std::vector<xla::Literal> PjRtComputationClient::TransferFromDevice(
       XLA_CHECK_OK(status) << "Failed to copy slice from local shard to global literal in"
                           << __FUNCTION__;
     }
-    total_size += literals[i].size_bytes();
   }
 
   InboundDataMetric()->AddSample(total_size);


### PR DESCRIPTION
### Summary

Replaces the device-side replication round-trip in `TransferFromDevice` with direct per-shard pulls and host-side stitching. On master, every sharded handle was funneled through `ReplicateShardedData`, which compiles and executes an XLA identity computation across all devices to produce a single replicated buffer before transferring it to host. This PR pulls each local shard directly to host and reassembles the global tensor on the host side from sharding metadata.