### PR TITLE
Release GIL during cached graph execution

### DIFF
--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -3407,9 +3407,15 @@ void InitXlaModuleBindings(py::module m) {
              // Device will be Virtual device if SPMD is enabled.
              torch::lazy::BackendDevice device =
                  torch_xla::bridge::GetCurrentDevice();
-             auto results =
-                 XLAGraphExecutor::Get()->ExecuteComputationWithBarrier(
-                     hash, graph_inputs, device);
+             std::vector<torch::lazy::BackendDataPtr> results;
+             {
+               // Release the GIL while executing the graph. PJRT plugins may
+               // run Python during execution (e.g. tt-xla EmitPy codegen) and
+               // holding the GIL here deadlocks against them.
+               NoGilSection nogil;
+               results = XLAGraphExecutor::Get()->ExecuteComputationWithBarrier(
+                   hash, graph_inputs, device);
+             }
              std::vector<at::Tensor> retlist;
              {
                TORCH_LAZY_TIMED("RunCachedGraphOutputData");


### PR DESCRIPTION
### Problem description
The `_run_cached_graph` pybind binding (dynamo bridge execution path) holds the GIL through `ExecuteComputationWithBarrier`, which blocks until the previous async execution completes. PJRT plugins may need to run Python during graph execution — tt-xla's EmitPy codegen backend executes generated `main.py` via an embedded interpreter on a PJRT worker thread — so holding the GIL here deadlocks: the main thread waits on the execution while the worker waits on the GIL. Lazy-tensor sync paths already release the GIL, so the deadlock only manifests for `torch.compile(backend="tt")`-wrapped calls (e.g. vLLM's compute_logits/sampling).

### What's changed
Wrapped the `ExecuteComputationWithBarrier` call in `NoGilSection`, consistent with the ~50 existing uses of that pattern in `init_python_bindings.cpp`. Inputs (`hash`, `device`, `graph_inputs`) are GIL-free C++ values; output conversion to `at::Tensor` happens after the GIL is restored. The only Python touchpoint inside the call (`GetPythonFrames` for debug analysis) guards itself with `gil_scoped_acquire` and is safe.

Verified end-to-end: a vLLM TP run with EmitPy live execution that deadlocked on first `compute_logits` now completes and generates tokens identical to the flatbuffer path.

### Checklist
- [ ] New/Existing tests provide coverage for changes