### PR TITLE
Use builder machines when building the wheel

### DIFF
--- a/.github/workflows/_build_torch_xla_release.yml
+++ b/.github/workflows/_build_torch_xla_release.yml
@@ -38,7 +38,7 @@ on:
         default: 'master'
 jobs:
   build-wheels:
-    runs-on: ubuntu-latest
+    runs-on: tt-ubuntu-2204-large-stable
     timeout-minutes: 540
     env:
       ARTIFACT_NAME: install-artifact-torch-xla-release-${{ inputs.python_version }}

--- a/.github/workflows/_build_torch_xla_release.yml
+++ b/.github/workflows/_build_torch_xla_release.yml
@@ -38,7 +38,7 @@ on:
         default: 'master'
 jobs:
   build-wheels:
-    runs-on: tt-ubuntu-2204-large-stable
+    runs-on: ['in-service', 'builder']
     timeout-minutes: 540
     env:
       ARTIFACT_NAME: install-artifact-torch-xla-release-${{ inputs.python_version }}


### PR DESCRIPTION
### Problem
Building the wheel takes too long on `ubuntu-latest` runners

### Changes
- Use CIv1 builder machines for building the wheel

### Validation
- [workflow](https://github.com/tenstorrent/pytorch-xla/actions/runs/28940373794/job/85860843685) example of the built wheel