### PR TITLE
Fix Python wheels failing to publish

### DIFF
--- a/.github/workflows/_build_torch_xla_release.yml
+++ b/.github/workflows/_build_torch_xla_release.yml
@@ -92,10 +92,7 @@ jobs:
         run: |
           apt-get update && apt-get install -y curl git build-essential
 
-          # Bazel's @local_config_python caches the interpreter's absolute path and
-          # declares no dependency on it, so its output base must go whenever pyenv does.
-          # /github/home persists between jobs, so this runs at the start to be self-healing:
-          # a job that dies mid-build leaves both trees for the next job to clear.
+          # Bazel caches pyenv's absolute paths; clear the pair together, at the start.
           rm -rf $HOME/.pyenv $HOME/.cache/bazel
 
           curl https://pyenv.run | bash
@@ -105,8 +102,7 @@ jobs:
           pyenv global ${{ inputs.python_version }}
           ln -sf $(pyenv which python${{ inputs.python_version }}) /usr/local/bin/python${{ inputs.python_version }}
 
-          # Without this, python_repo.bzl infers the hermetic version from
-          # `python3 --version` -- an input Bazel does not track.
+          # Or python_repo.bzl infers it from `python3 --version`, which Bazel won't track.
           export HERMETIC_PYTHON_VERSION=${{ inputs.python_version }}
 
           # Install essential packages for Python ${{ inputs.python_version }}

--- a/.github/workflows/_build_torch_xla_release.yml
+++ b/.github/workflows/_build_torch_xla_release.yml
@@ -92,31 +92,22 @@ jobs:
         run: |
           apt-get update && apt-get install -y curl git build-essential
 
-          PY=${{ inputs.python_version }}
+          # Bazel's @local_config_python caches the interpreter's absolute path and
+          # declares no dependency on it, so its output base must go whenever pyenv does.
+          # /github/home persists between jobs, so this runs at the start to be self-healing:
+          # a job that dies mid-build leaves both trees for the next job to clear.
+          rm -rf $HOME/.pyenv $HOME/.cache/bazel
 
-          # /github/home persists between jobs, and Bazel bakes absolute interpreter paths
-          # into @local_config_python untracked. So: one pyenv tree and one Bazel base per
-          # full interpreter version, never deleted, or the base referencing it breaks.
-          export PYENV_ROOT="/github/home/pyenv/$PY"
-          export PATH="$PYENV_ROOT/bin:$PATH"
-          if [ ! -x "$PYENV_ROOT/bin/pyenv" ]; then
-            rm -rf "$PYENV_ROOT"
-            curl https://pyenv.run | bash
-          fi
+          curl https://pyenv.run | bash
+          export PATH="$HOME/.pyenv/bin:$PATH"
           eval "$(pyenv init -)"
-          pyenv install -s $PY
-          pyenv global $PY
-          ln -sf $(pyenv which python$PY) /usr/local/bin/python$PY
+          pyenv install ${{ inputs.python_version }}
+          pyenv global ${{ inputs.python_version }}
+          ln -sf $(pyenv which python${{ inputs.python_version }}) /usr/local/bin/python${{ inputs.python_version }}
 
-          PY_FULL=$(basename "$(python$PY -c 'import sys; print(sys.prefix)')")
-          BAZEL_OUTPUT_USER_ROOT="/github/home/bazel/$PY_FULL"
-          mkdir -p "$BAZEL_OUTPUT_USER_ROOT" && touch "$BAZEL_OUTPUT_USER_ROOT"
-          # Bases untouched for two weeks; the mkdir/touch above keeps this one current.
-          find /github/home/bazel -mindepth 1 -maxdepth 1 -type d -mtime +14 \
-            -not -path "$BAZEL_OUTPUT_USER_ROOT" -exec rm -rf {} + || true
-
-          # Without this, python_repo.bzl infers it from `python3 --version`, untracked.
-          export HERMETIC_PYTHON_VERSION=$PY
+          # Without this, python_repo.bzl infers the hermetic version from
+          # `python3 --version` -- an input Bazel does not track.
+          export HERMETIC_PYTHON_VERSION=${{ inputs.python_version }}
 
           # Install essential packages for Python ${{ inputs.python_version }}
           python${{ inputs.python_version }} -m pip install --upgrade pip
@@ -141,9 +132,7 @@ jobs:
 
           # Build PyTorch/XLA
           cd xla/
-          # try-imported by .bazelrc; setup.py owns the bazel command line.
-          echo "startup --output_user_root=$BAZEL_OUTPUT_USER_ROOT" > .bazelrc.user
-          MAX_JOBS=8 BAZEL_JOBS=8 python$PY setup.py bdist_wheel
+          MAX_JOBS=8 BAZEL_JOBS=8 python${{ inputs.python_version }} setup.py bdist_wheel
 
           # Collect wheels
           mkdir -p /dist

--- a/.github/workflows/_build_torch_xla_release.yml
+++ b/.github/workflows/_build_torch_xla_release.yml
@@ -99,7 +99,7 @@ jobs:
           # exit so a cross-version landing is self-evident from the log alone.
           show_builder_state() {
             echo "== persistent builder state ($1) =="
-            for d in /github/home/.pyenv /github/home/.cache/bazel \
+            for d in /github/home/.pyenv/versions /github/home/.cache/bazel \
                      /github/home/pyenv /github/home/bazel; do
               printf '  %s: ' "$d"
               if [ -d "$d" ]; then ls -1 "$d" 2>/dev/null | tr '\n' ' '; else printf 'absent'; fi

--- a/.github/workflows/_build_torch_xla_release.yml
+++ b/.github/workflows/_build_torch_xla_release.yml
@@ -94,17 +94,6 @@ jobs:
 
           PY=${{ inputs.python_version }}
 
-          show_builder_state() {
-            echo "== persistent builder state ($1) =="
-            for d in /github/home/.pyenv/versions /github/home/.cache/bazel \
-                     /github/home/pyenv /github/home/bazel; do
-              printf '  %s: ' "$d"
-              if [ -d "$d" ]; then ls -1 "$d" 2>/dev/null | tr '\n' ' '; else printf 'absent'; fi
-              echo
-            done
-          }
-          show_builder_state inherited
-
           # /github/home persists between jobs, and Bazel bakes absolute interpreter paths
           # into @local_config_python untracked. So: one pyenv tree and one Bazel base per
           # full interpreter version, never deleted, or the base referencing it breaks.
@@ -159,8 +148,6 @@ jobs:
           # Collect wheels
           mkdir -p /dist
           cp dist/*.whl /dist/
-
-          show_builder_state "left behind"
 
       - name: "Upload Wheels Artifact"
         id: upload

--- a/.github/workflows/_build_torch_xla_release.yml
+++ b/.github/workflows/_build_torch_xla_release.yml
@@ -92,15 +92,51 @@ jobs:
         run: |
           apt-get update && apt-get install -y curl git build-essential
 
-          # Clean up any existing pyenv installation
-          rm -rf $HOME/.pyenv
+          PY=${{ inputs.python_version }}
 
-          curl https://pyenv.run | bash
-          export PATH="$HOME/.pyenv/bin:$PATH"
+          # /github/home is a volume that persists across every job landing on this
+          # builder, and it holds both the pyenv trees and the Bazel output bases.
+          # Bazel's @local_config_python (pybind11_bazel's python_configure) bakes the
+          # absolute path of the local interpreter into its cached external repo and
+          # declares no dependency on the interpreter, so it is never re-fetched when the
+          # interpreter changes. The old layout installed every version's pyenv at the
+          # same path and deleted it at the end of the job, so a 3.11 job landing on a
+          # builder that had last built 3.12 aborted analysis with:
+          #   Inconsistent filesystem operations. /github/home/.pyenv/versions/3.12.13/bin
+          #   is no longer an existing directory.
+          # Give each interpreter its own pyenv tree and its own Bazel output base, at
+          # stable paths that are never deleted, so the versions cannot observe each
+          # other's state.
+
+          # Reclaim the pre-fix shared state: dangling interpreter paths plus tens of GB
+          # of output that nothing references any more.
+          rm -rf /github/home/.pyenv /github/home/.cache/bazel
+
+          export PYENV_ROOT="/github/home/pyenv/$PY"
+          export PATH="$PYENV_ROOT/bin:$PATH"
+          if [ ! -x "$PYENV_ROOT/bin/pyenv" ]; then
+            rm -rf "$PYENV_ROOT"
+            curl https://pyenv.run | bash
+          fi
           eval "$(pyenv init -)"
-          pyenv install ${{ inputs.python_version }}
-          pyenv global ${{ inputs.python_version }}
-          ln -sf $(pyenv which python${{ inputs.python_version }}) /usr/local/bin/python${{ inputs.python_version }}
+          pyenv install -s $PY
+          pyenv global $PY
+          ln -sf $(pyenv which python$PY) /usr/local/bin/python$PY
+
+          # Key the Bazel output base on the full interpreter version, so a pyenv patch
+          # bump gets a fresh base instead of leaving dangling paths in an existing one.
+          PY_FULL=$(basename "$(python$PY -c 'import sys; print(sys.prefix)')")
+          BAZEL_OUTPUT_USER_ROOT="/github/home/bazel/$PY_FULL"
+          mkdir -p "$BAZEL_OUTPUT_USER_ROOT" && touch "$BAZEL_OUTPUT_USER_ROOT"
+          # Drop bases unused for two weeks so patch bumps do not pile up on the builder.
+          find /github/home/bazel -mindepth 1 -maxdepth 1 -type d -mtime +14 \
+            -not -path "$BAZEL_OUTPUT_USER_ROOT" -exec rm -rf {} + || true
+
+          # Pin the hermetic interpreter explicitly. Otherwise XLA's python_repo.bzl
+          # infers it by shelling out to `python3 --version` (WORKSPACE passes
+          # default_python_version = "system"), which Bazel does not track and which
+          # depends on whatever pyenv's global setting happens to be.
+          export HERMETIC_PYTHON_VERSION=$PY
 
           # Install essential packages for Python ${{ inputs.python_version }}
           python${{ inputs.python_version }} -m pip install --upgrade pip
@@ -125,14 +161,14 @@ jobs:
 
           # Build PyTorch/XLA
           cd xla/
-          MAX_JOBS=8 BAZEL_JOBS=8 python${{ inputs.python_version }} setup.py bdist_wheel
+          # .bazelrc try-imports this; it is the only way to reach a startup option,
+          # since setup.py owns the bazel command line.
+          echo "startup --output_user_root=$BAZEL_OUTPUT_USER_ROOT" > .bazelrc.user
+          MAX_JOBS=8 BAZEL_JOBS=8 python$PY setup.py bdist_wheel
 
           # Collect wheels
           mkdir -p /dist
           cp dist/*.whl /dist/
-
-          # Clean up any existing pyenv installation
-          rm -rf $HOME/.pyenv
 
       - name: "Upload Wheels Artifact"
         id: upload

--- a/.github/workflows/_build_torch_xla_release.yml
+++ b/.github/workflows/_build_torch_xla_release.yml
@@ -94,9 +94,8 @@ jobs:
 
           PY=${{ inputs.python_version }}
 
-          # This bug was invisible builder state: nothing in the log said which
-          # interpreter or Bazel base a job inherited. Record the inventory on entry and
-          # exit so a cross-version landing is self-evident from the log alone.
+          # Builders carry state between jobs, so log which interpreter trees and Bazel
+          # bases this job inherited and what it leaves for the next one.
           show_builder_state() {
             echo "== persistent builder state ($1) =="
             for d in /github/home/.pyenv/versions /github/home/.cache/bazel \
@@ -108,22 +107,16 @@ jobs:
           }
           show_builder_state inherited
 
-          # /github/home is a volume that persists across every job landing on this
-          # builder, and it holds both the pyenv trees and the Bazel output bases.
-          # Bazel's @local_config_python (pybind11_bazel's python_configure) bakes the
-          # absolute path of the local interpreter into its cached external repo and
-          # declares no dependency on the interpreter, so it is never re-fetched when the
-          # interpreter changes. The old layout installed every version's pyenv at the
-          # same path and deleted it at the end of the job, so a 3.11 job landing on a
-          # builder that had last built 3.12 aborted analysis with:
-          #   Inconsistent filesystem operations. /github/home/.pyenv/versions/3.12.13/bin
-          #   is no longer an existing directory.
-          # Give each interpreter its own pyenv tree and its own Bazel output base, at
-          # stable paths that are never deleted, so the versions cannot observe each
-          # other's state.
+          # /github/home persists across jobs on a builder. Bazel bakes the absolute path
+          # of the local interpreter into @local_config_python (pybind11_bazel's
+          # python_configure) and declares no dependency on it, so one Python version's
+          # state must never be reachable from another's build: each version gets its own
+          # pyenv tree and its own Bazel output base, at stable paths, never deleted.
+          # Removing either interpreter tree while a Bazel base still references it makes
+          # that base unusable.
 
-          # Reclaim the pre-fix shared state: dangling interpreter paths plus tens of GB
-          # of output that nothing references any more.
+          # Shared layout predating the per-version roots; a no-op once a builder has run
+          # this once.
           rm -rf /github/home/.pyenv /github/home/.cache/bazel
 
           export PYENV_ROOT="/github/home/pyenv/$PY"
@@ -137,8 +130,8 @@ jobs:
           pyenv global $PY
           ln -sf $(pyenv which python$PY) /usr/local/bin/python$PY
 
-          # Key the Bazel output base on the full interpreter version, so a pyenv patch
-          # bump gets a fresh base instead of leaving dangling paths in an existing one.
+          # Keyed on the full version, not the minor: a pyenv patch bump moves the
+          # interpreter path, and must therefore get its own base.
           PY_FULL=$(basename "$(python$PY -c 'import sys; print(sys.prefix)')")
           BAZEL_OUTPUT_USER_ROOT="/github/home/bazel/$PY_FULL"
           mkdir -p "$BAZEL_OUTPUT_USER_ROOT" && touch "$BAZEL_OUTPUT_USER_ROOT"
@@ -146,10 +139,9 @@ jobs:
           find /github/home/bazel -mindepth 1 -maxdepth 1 -type d -mtime +14 \
             -not -path "$BAZEL_OUTPUT_USER_ROOT" -exec rm -rf {} + || true
 
-          # Pin the hermetic interpreter explicitly. Otherwise XLA's python_repo.bzl
-          # infers it by shelling out to `python3 --version` (WORKSPACE passes
-          # default_python_version = "system"), which Bazel does not track and which
-          # depends on whatever pyenv's global setting happens to be.
+          # WORKSPACE passes default_python_version = "system", so without this XLA's
+          # python_repo.bzl infers the hermetic version from `python3 --version` — an
+          # input Bazel does not track. Pin it so the requirements lock is explicit.
           export HERMETIC_PYTHON_VERSION=$PY
 
           # Install essential packages for Python ${{ inputs.python_version }}

--- a/.github/workflows/_build_torch_xla_release.yml
+++ b/.github/workflows/_build_torch_xla_release.yml
@@ -94,8 +94,6 @@ jobs:
 
           PY=${{ inputs.python_version }}
 
-          # Builders carry state between jobs, so log which interpreter trees and Bazel
-          # bases this job inherited and what it leaves for the next one.
           show_builder_state() {
             echo "== persistent builder state ($1) =="
             for d in /github/home/.pyenv/versions /github/home/.cache/bazel \
@@ -107,14 +105,9 @@ jobs:
           }
           show_builder_state inherited
 
-          # /github/home persists across jobs on a builder. Bazel bakes the absolute path
-          # of the local interpreter into @local_config_python (pybind11_bazel's
-          # python_configure) and declares no dependency on it, so one Python version's
-          # state must never be reachable from another's build: each version gets its own
-          # pyenv tree and its own Bazel output base, at stable paths, never deleted.
-          # Removing either interpreter tree while a Bazel base still references it makes
-          # that base unusable.
-
+          # /github/home persists between jobs, and Bazel bakes absolute interpreter paths
+          # into @local_config_python untracked. So: one pyenv tree and one Bazel base per
+          # full interpreter version, never deleted, or the base referencing it breaks.
           export PYENV_ROOT="/github/home/pyenv/$PY"
           export PATH="$PYENV_ROOT/bin:$PATH"
           if [ ! -x "$PYENV_ROOT/bin/pyenv" ]; then
@@ -126,18 +119,14 @@ jobs:
           pyenv global $PY
           ln -sf $(pyenv which python$PY) /usr/local/bin/python$PY
 
-          # Keyed on the full version, not the minor: a pyenv patch bump moves the
-          # interpreter path, and must therefore get its own base.
           PY_FULL=$(basename "$(python$PY -c 'import sys; print(sys.prefix)')")
           BAZEL_OUTPUT_USER_ROOT="/github/home/bazel/$PY_FULL"
           mkdir -p "$BAZEL_OUTPUT_USER_ROOT" && touch "$BAZEL_OUTPUT_USER_ROOT"
-          # Drop bases unused for two weeks so patch bumps do not pile up on the builder.
+          # Bases untouched for two weeks; the mkdir/touch above keeps this one current.
           find /github/home/bazel -mindepth 1 -maxdepth 1 -type d -mtime +14 \
             -not -path "$BAZEL_OUTPUT_USER_ROOT" -exec rm -rf {} + || true
 
-          # WORKSPACE passes default_python_version = "system", so without this XLA's
-          # python_repo.bzl infers the hermetic version from `python3 --version` — an
-          # input Bazel does not track. Pin it so the requirements lock is explicit.
+          # Without this, python_repo.bzl infers it from `python3 --version`, untracked.
           export HERMETIC_PYTHON_VERSION=$PY
 
           # Install essential packages for Python ${{ inputs.python_version }}
@@ -163,8 +152,7 @@ jobs:
 
           # Build PyTorch/XLA
           cd xla/
-          # .bazelrc try-imports this; it is the only way to reach a startup option,
-          # since setup.py owns the bazel command line.
+          # try-imported by .bazelrc; setup.py owns the bazel command line.
           echo "startup --output_user_root=$BAZEL_OUTPUT_USER_ROOT" > .bazelrc.user
           MAX_JOBS=8 BAZEL_JOBS=8 python$PY setup.py bdist_wheel
 

--- a/.github/workflows/_build_torch_xla_release.yml
+++ b/.github/workflows/_build_torch_xla_release.yml
@@ -94,6 +94,20 @@ jobs:
 
           PY=${{ inputs.python_version }}
 
+          # This bug was invisible builder state: nothing in the log said which
+          # interpreter or Bazel base a job inherited. Record the inventory on entry and
+          # exit so a cross-version landing is self-evident from the log alone.
+          show_builder_state() {
+            echo "== persistent builder state ($1) =="
+            for d in /github/home/.pyenv /github/home/.cache/bazel \
+                     /github/home/pyenv /github/home/bazel; do
+              printf '  %s: ' "$d"
+              if [ -d "$d" ]; then ls -1 "$d" 2>/dev/null | tr '\n' ' '; else printf 'absent'; fi
+              echo
+            done
+          }
+          show_builder_state inherited
+
           # /github/home is a volume that persists across every job landing on this
           # builder, and it holds both the pyenv trees and the Bazel output bases.
           # Bazel's @local_config_python (pybind11_bazel's python_configure) bakes the
@@ -169,6 +183,8 @@ jobs:
           # Collect wheels
           mkdir -p /dist
           cp dist/*.whl /dist/
+
+          show_builder_state "left behind"
 
       - name: "Upload Wheels Artifact"
         id: upload

--- a/.github/workflows/_build_torch_xla_release.yml
+++ b/.github/workflows/_build_torch_xla_release.yml
@@ -144,3 +144,8 @@ jobs:
       - name: Set artifact name output
         id: set_upload_name
         run: echo "artifact_name=${{ env.ARTIFACT_NAME }}" >> $GITHUB_OUTPUT
+
+      - name: "Release the builder's disk for the next job"
+        if: always()
+        shell: bash
+        run: rm -rf $HOME/.pyenv $HOME/.cache/bazel || true

--- a/.github/workflows/_build_torch_xla_release.yml
+++ b/.github/workflows/_build_torch_xla_release.yml
@@ -115,10 +115,6 @@ jobs:
           # Removing either interpreter tree while a Bazel base still references it makes
           # that base unusable.
 
-          # Shared layout predating the per-version roots; a no-op once a builder has run
-          # this once.
-          rm -rf /github/home/.pyenv /github/home/.cache/bazel
-
           export PYENV_ROOT="/github/home/pyenv/$PY"
           export PATH="$PYENV_ROOT/bin:$PATH"
           if [ ! -x "$PYENV_ROOT/bin/pyenv" ]; then

--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -12,6 +12,9 @@ on:
         options:
           - '3.11'
           - '3.12'
+          # Mirrors what a push to master does, so the two-version path can be
+          # exercised manually instead of only by landing on master.
+          - 'all'
         default: '3.11'
 
 concurrency:
@@ -32,22 +35,30 @@ jobs:
     if: needs.check_code_changes.outputs.has_code_changes == 'true'
     needs: check_code_changes
     strategy:
+      # The versions are independent, so one failing must not cancel the other: that
+      # throws away a ~100 minute build and leaves nothing to publish.
+      fail-fast: false
       matrix:
-        # On push to master: build all versions ["3.11", "3.12"]
+        # On push to master, or a manual trigger with 'all': build ["3.11", "3.12"]
         # On manual trigger: build only the selected inputs.python_version
-        python_version: ${{ github.event_name == 'push' && fromJSON('["3.11", "3.12"]') || fromJSON(format('["{0}"]', inputs.python_version)) }}
+        python_version: ${{ (github.event_name == 'push' || inputs.python_version == 'all') && fromJSON('["3.11", "3.12"]') || fromJSON(format('["{0}"]', inputs.python_version)) }}
     uses: ./.github/workflows/_build_torch_xla_release.yml
     with:
       python_version: ${{ matrix.python_version }}
 
   publish-torch-xla:
     name: "Publish PyTorch/XLA Python ${{ matrix.python_version }}"
-    if: ${{ !cancelled() && !failure() }}
+    # `needs` cannot be narrowed to a single matrix leg, so this depends on the whole
+    # build matrix. Gate on the build not being skipped rather than on !failure(), so one
+    # version failing to build still lets the other publish; the leg whose wheel is
+    # missing then fails loudly on download instead of silently skipping both.
+    if: ${{ !cancelled() && needs['build-torch-xla'].result != 'skipped' }}
     needs: build-torch-xla
     strategy:
+      fail-fast: false
       matrix:
         # Matches the build job matrix to publish the same versions that were built
-        python_version: ${{ github.event_name == 'push' && fromJSON('["3.11", "3.12"]') || fromJSON(format('["{0}"]', inputs.python_version)) }}
+        python_version: ${{ (github.event_name == 'push' || inputs.python_version == 'all') && fromJSON('["3.11", "3.12"]') || fromJSON(format('["{0}"]', inputs.python_version)) }}
     uses: ./.github/workflows/_publish_torch_xla.yml
     secrets: inherit
     permissions:

--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -12,8 +12,6 @@ on:
         options:
           - '3.11'
           - '3.12'
-          # Mirrors what a push to master does, so the two-version path can be
-          # exercised manually instead of only by landing on master.
           - 'all'
         default: '3.11'
 
@@ -35,8 +33,6 @@ jobs:
     if: needs.check_code_changes.outputs.has_code_changes == 'true'
     needs: check_code_changes
     strategy:
-      # The versions are independent, so one failing must not cancel the other: that
-      # throws away a ~100 minute build and leaves nothing to publish.
       fail-fast: false
       matrix:
         # On push to master, or a manual trigger with 'all': build ["3.11", "3.12"]
@@ -48,10 +44,6 @@ jobs:
 
   publish-torch-xla:
     name: "Publish PyTorch/XLA Python ${{ matrix.python_version }}"
-    # `needs` cannot be narrowed to a single matrix leg, so this depends on the whole
-    # build matrix. Gate on the build not being skipped rather than on !failure(), so one
-    # version failing to build still lets the other publish; the leg whose wheel is
-    # missing then fails loudly on download instead of silently skipping both.
     if: ${{ !cancelled() && needs['build-torch-xla'].result != 'skipped' }}
     needs: build-torch-xla
     strategy:


### PR DESCRIPTION
**Human TLDR:** Fix the publishing of Python packages that was failing on main.
I decided to keep support for multiple versions in case we need to add more in the future and the problem was not really 3.11 by itself but the multi-version publish workflow, which this MR fixes.

AI details follow:

## Problem

Publishing produced no wheels. On the last push to master the 3.11 build died in `bazel build //:_XLAC.so` after ~50 min — note the **3.12** path in a **3.11** job — and took the whole matrix with it:

```
ERROR: Analysis of target '//:_XLAC.so' failed; build aborted: Inconsistent filesystem
operations. /github/home/.pyenv/versions/3.12.13/bin is no longer an existing directory.

Build PyTorch/XLA Python 3.12                            cancelled
Build PyTorch/XLA Python 3.11                            failure
Publish PyTorch/XLA Python ${{ matrix.python_version }}  skipped   ← matrix never expanded
```

## Cause

**1. pyenv and the Bazel cache are one unit of state, treated as two.** `/github/home` persists between jobs on the `builder` pool and holds both. `local_config_python` (pybind11_bazel's `python_configure`) bakes the interpreter's **absolute** path into its cached external repo and declares no dependency on the interpreter, so it never re-fetches when that interpreter changes. The workflow deleted `$HOME/.pyenv` at the end of each job and left the Bazel base in place, so the next job's cache referenced an interpreter that no longer existed. The failure was therefore **sticky per builder, not per version** — 3.11 failed on builder-6 and builder-5, both of which had last built 3.12, while 3.12 passed on builder-1. Separately, `default_python_version = "system"` in `WORKSPACE` left the hermetic version to be inferred from `python3 --version`, which Bazel does not track.

**2. The matrix legs were coupled.** No `fail-fast: false`, so one version failing cancelled the other mid-build; and `publish-torch-xla` gated on `!failure()` across the whole build matrix, so one build failing meant *neither* version published.

## Fix

- **Delete the Bazel output base alongside pyenv, at the start of the step.** Clearing both together removes the inconsistency. Start-of-step is self-healing: the old trailing `rm -rf` was skipped whenever an earlier command failed, which is how builders kept a stale `.pyenv` for weeks. Only `.cache/bazel` is removed; the rest of `.cache` stays.
- **`export HERMETIC_PYTHON_VERSION`**, so the requirements lock is chosen explicitly instead of inferred from an untracked input.
- **`fail-fast: false` on both matrices**, and publish now gates on the build not being **skipped**, so a missing wheel fails its own leg loudly instead of silencing both. `needs` cannot be narrowed to one matrix leg, so the gate covers the whole matrix. `workflow_dispatch` gains an `all` option, making the multi-version path reachable without landing on master.

The cost is that every build starts from a cold Bazel base — about 48 minutes for `_XLAC.so`.

## A more surgical approach was proposed first, and abandoned

Earlier revisions kept the state and gave each Python version its own pyenv tree and Bazel output base, so the two could not collide. It worked: twelve builds passed, including a 3.11 build on a builder holding 3.12 state, and a warm rebuild dropped to 3 actions in ~25s. It was dropped on review. The speedup needs a build to land on a builder that recently built the same version — roughly one chance in nine across this pool — and it asks a reviewer to trust Bazel cache reuse in precisely the case where our own bug showed it can go stale while believing itself valid. Wiping is a two-line change that needs no such trust. The commits remain on the branch if the caching is ever worth revisiting.

## Validation

Retest of the current code is in flight: [30474367715](https://github.com/tenstorrent/pytorch-xla/actions/runs/30474367715) (3.11) and [30474369759](https://github.com/tenstorrent/pytorch-xla/actions/runs/30474369759) (3.12), dispatched build-only to skip the publish step, which cannot run from a branch.

Established already and unaffected by the change of approach: both publish legs expand and run independently, which the OIDC failure demonstrated for real — 3.11's leg failed while 3.12's kept running instead of being cancelled. The upload itself is untestable from a branch, since the role rejects non-master refs (`Not authorized to perform sts:AssumeRoleWithWebIdentity`). It first runs on merge, which is also what will publish master's missing cp311 wheel.

A separate finding came out of the investigation and is worth reading on its own: `RUNNER_TEMP` is never cleared on these builders, because job containers run as root and the runner cannot delete what they leave behind. [Report](https://claude.ai/code/artifact/23cadaca-33c5-4acb-aed2-a3c310dcc0db).
