### PR TITLE
Uplift jax/jaxlib to 0.11.0 and OpenXLA to 131bf41a

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -30,7 +30,12 @@ build --copt=-fexceptions
 # Force GCC because clang/bazel has issues.
 build --action_env=CC=gcc
 build --action_env=CXX=g++
-build --spawn_strategy=sandboxed
+build --spawn_strategy=standalone
+# Sandbox only C++ compiles so the undeclared PyTorch source tree is invisible to
+# the compiler (torch quote-includes then resolve to torch/include, not the source
+# copies -> no duplicate-inode redefinitions). Genrules stay on the default
+# strategy; some (e.g. @local_config_python) cannot run sandboxed.
+build --strategy=CppCompile=sandboxed
 
 # TODO(https://github.com/pytorch/xla/issues/9336): Enable bzlmod.
 build --noenable_bzlmod

--- a/.bazelrc
+++ b/.bazelrc
@@ -102,6 +102,12 @@ build:nonccl --define=no_nccl_support=true
 
 build:linux --config=posix
 
+# Hermetic sysroot override: the default (linux_glibc_2_27, GCC 8.4) ships the
+# pre-GCC-9 std::filesystem::__cxx11::path, whose layout mismatches the GCC-12/14
+# runtime libstdc++ and crashes torch_xla's PersistentCache. GCC 10 has the stable
+# filesystem::path ABI; glibc 2.31 stays within tt-xla's manylinux_2_34 floor.
+build:linux --repo_env=SYSROOT_DIST=linux_glibc_2_31
+
 # Suppress all warning messages.
 build:short_logs --output_filter=DONT_MATCH_ANYTHING
 

--- a/.bazelrc
+++ b/.bazelrc
@@ -30,7 +30,7 @@ build --copt=-fexceptions
 # Force GCC because clang/bazel has issues.
 build --action_env=CC=gcc
 build --action_env=CXX=g++
-build --spawn_strategy=standalone
+build --spawn_strategy=sandboxed
 
 # TODO(https://github.com/pytorch/xla/issues/9336): Enable bzlmod.
 build --noenable_bzlmod

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ MODULE.bazel.lock
 
 # Clangd cache directory.
 .cache/*
+
+# Local build/dev virtualenv (never commit)
+venv/

--- a/BUILD
+++ b/BUILD
@@ -3,7 +3,10 @@ load(
     "if_cuda_is_configured",
 )
 
-load("@python//:defs.bzl", "compile_pip_requirements")
+# Newer rules_ml_toolchain names the hermetic Python hub repo per-version
+# (e.g. @python_3_12) rather than a plain @python, so load
+# compile_pip_requirements from its canonical, version-independent location.
+load("@rules_python//python:pip.bzl", "compile_pip_requirements")
 load("@python_version_repo//:py_version.bzl", "REQUIREMENTS")
 
 compile_pip_requirements(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -93,6 +93,30 @@ load("@xla//:workspace3.bzl", "xla_workspace3")
 
 xla_workspace3()
 
+load("@bazel_features//:deps.bzl", "bazel_features_deps")
+
+bazel_features_deps()
+
+# Initialize hermetic C++ toolchain. Newer OpenXLA (jax 0.11 era) compiles with
+# the rules_ml_toolchain hermetic clang instead of an autodetected system
+# compiler; cc_toolchain_deps() defines @llvm_linux_x86_64 (and friends) that
+# the workspace2 cc configuration transitively loads.
+load("@rules_ml_toolchain//cc/deps:cc_toolchain_deps.bzl", "cc_toolchain_deps")
+
+cc_toolchain_deps()
+
+register_toolchains("@rules_ml_toolchain//cc:linux_x86_64_linux_x86_64")
+
+register_toolchains("@rules_ml_toolchain//cc:linux_x86_64_linux_x86_64_cuda")
+
+register_toolchains("@rules_ml_toolchain//cc:linux_x86_64_linux_x86_64_sycl")
+
+register_toolchains("@rules_ml_toolchain//cc:linux_x86_64_linux_x86_64_rocm")
+
+register_toolchains("@rules_ml_toolchain//cc:linux_aarch64_linux_aarch64")
+
+register_toolchains("@rules_ml_toolchain//cc:linux_aarch64_linux_aarch64_cuda")
+
 # Initialize hermetic Python
 load("@xla//third_party/py:python_init_rules.bzl", "python_init_rules")
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -79,6 +79,20 @@ http_archive(
 #    path = "/path/to/openxla",
 # )
 
+# Initialize OpenXLA's external dependencies. There is a specific order in
+# which these dependencies are initialized, because for bazel it's the first
+# definition that takes precedence. Newer OpenXLA (jax 0.11 era) defines
+# @rules_ml_toolchain in workspace4/workspace3, and the hermetic Python setup
+# below transitively depends on it, so workspace4/3 must run first. We follow
+# what openxla/xla and upstream pytorch/xla do exactly.
+load("@xla//:workspace4.bzl", "xla_workspace4")
+
+xla_workspace4()
+
+load("@xla//:workspace3.bzl", "xla_workspace3")
+
+xla_workspace3()
+
 # Initialize hermetic Python
 load("@xla//third_party/py:python_init_rules.bzl", "python_init_rules")
 
@@ -110,17 +124,6 @@ python_init_pip()
 load("@pypi//:requirements.bzl", "install_deps")
 
 install_deps()
-
-
-
-# Initialize OpenXLA's external dependencies.
-load("@xla//:workspace4.bzl", "xla_workspace4")
-
-xla_workspace4()
-
-load("@xla//:workspace3.bzl", "xla_workspace3")
-
-xla_workspace3()
 
 load("@xla//:workspace2.bzl", "xla_workspace2")
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -46,7 +46,7 @@ new_local_repository(
 
 # To build PyTorch/XLA with a new revison of OpenXLA, update the xla_hash to
 # the openxla git commit hash and note the date of the commit.
-xla_hash = '3d5ece64321630dade7ff733ae1353fc3c83d9cc'  # Committed on 2025-06-17.
+xla_hash = '131bf41acb4650e4391a640c3f1859c1c86ad74b'  # Committed on 2026-07-16. (jaxlib 0.11.0)
 
 http_archive(
     name = "xla",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -138,16 +138,15 @@ load("@xla//:workspace0.bzl", "xla_workspace0")
 xla_workspace0()
 
 
+# Even though we don't support XLA:CUDA, we still need @local_config_cuda so
+# that XLA BUILD files loading `@local_config_cuda//cuda:build_defs.bzl`
+# (if_cuda) resolve. With TF_NEED_CUDA unset this creates a dummy (no-CUDA)
+# repository. In XLA 131bf41a the non-hermetic `third_party/gpus:cuda_configure`
+# rule was removed; use the hermetic one. nccl is now initialized inside
+# xla_workspace2(), so no separate nccl_configure call is needed.
 load(
-    "@xla//third_party/gpus:cuda_configure.bzl",
+    "@xla//third_party/gpus/cuda/hermetic:cuda_configure.bzl",
     "cuda_configure",
 )
 
 cuda_configure(name = "local_config_cuda")
-
-load(
-    "@xla//third_party/nccl:nccl_configure.bzl",
-    "nccl_configure",
-)
-
-nccl_configure(name = "local_config_nccl")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -138,15 +138,86 @@ load("@xla//:workspace0.bzl", "xla_workspace0")
 xla_workspace0()
 
 
-# Even though we don't support XLA:CUDA, we still need @local_config_cuda so
-# that XLA BUILD files loading `@local_config_cuda//cuda:build_defs.bzl`
-# (if_cuda) resolve. With TF_NEED_CUDA unset this creates a dummy (no-CUDA)
-# repository. In XLA 131bf41a the non-hermetic `third_party/gpus:cuda_configure`
-# rule was removed; use the hermetic one. nccl is now initialized inside
-# xla_workspace2(), so no separate nccl_configure call is needed.
+# Hermetic CUDA / NCCL / nvSHMEM setup, mirroring openxla/xla's WORKSPACE for
+# this XLA revision. Even though we build CPU-only, XLA BUILD files pervasively
+# load @local_config_cuda and @local_config_nccl (if_cuda/if_nccl), so these
+# repositories must be defined; with CUDA disabled they resolve to dummy
+# (no-CUDA) repositories. In XLA 131bf41a this setup moved to
+# @rules_ml_toolchain//gpu/... and cuda_configure now requires the CUDA redist
+# repositories (@cuda_cudart, @cuda_nvtx, ...) to be defined first.
 load(
-    "@xla//third_party/gpus/cuda/hermetic:cuda_configure.bzl",
+    "@rules_ml_toolchain//gpu/cuda:cuda_json_init_repository.bzl",
+    "cuda_json_init_repository",
+)
+
+cuda_json_init_repository()
+
+load(
+    "@cuda_redist_json//:distributions.bzl",
+    "CUDA_REDISTRIBUTIONS",
+    "CUDNN_REDISTRIBUTIONS",
+)
+load(
+    "@rules_ml_toolchain//gpu/cuda:cuda_redist_init_repositories.bzl",
+    "cuda_redist_init_repositories",
+    "cudnn_redist_init_repository",
+)
+load(
+    "@rules_ml_toolchain//gpu/cuda:cuda_redist_versions.bzl",
+    "REDIST_VERSIONS_TO_BUILD_TEMPLATES",
+)
+load(
+    "@xla//third_party/cccl:workspace.bzl",
+    "CCCL_3_2_0_DIST_DICT",
+    "CCCL_GITHUB_VERSIONS_TO_BUILD_TEMPLATES",
+)
+
+cuda_redist_init_repositories(
+    cuda_redistributions = CUDA_REDISTRIBUTIONS | CCCL_3_2_0_DIST_DICT,
+    redist_versions_to_build_templates = REDIST_VERSIONS_TO_BUILD_TEMPLATES | CCCL_GITHUB_VERSIONS_TO_BUILD_TEMPLATES,
+)
+
+cudnn_redist_init_repository(
+    cudnn_redistributions = CUDNN_REDISTRIBUTIONS,
+)
+
+load(
+    "@rules_ml_toolchain//gpu/cuda:cuda_configure.bzl",
     "cuda_configure",
 )
 
 cuda_configure(name = "local_config_cuda")
+
+load(
+    "@rules_ml_toolchain//gpu/nccl:nccl_redist_init_repository.bzl",
+    "nccl_redist_init_repository",
+)
+
+nccl_redist_init_repository()
+
+load(
+    "@rules_ml_toolchain//gpu/nccl:nccl_configure.bzl",
+    "nccl_configure",
+)
+
+nccl_configure(name = "local_config_nccl")
+
+load(
+    "@rules_ml_toolchain//gpu/nvshmem:nvshmem_json_init_repository.bzl",
+    "nvshmem_json_init_repository",
+)
+
+nvshmem_json_init_repository()
+
+load(
+    "@nvshmem_redist_json//:distributions.bzl",
+    "NVSHMEM_REDISTRIBUTIONS",
+)
+load(
+    "@rules_ml_toolchain//gpu/nvshmem:nvshmem_redist_init_repository.bzl",
+    "nvshmem_redist_init_repository",
+)
+
+nvshmem_redist_init_repository(
+    nvshmem_redistributions = NVSHMEM_REDISTRIBUTIONS,
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -56,8 +56,6 @@ http_archive(
     ],
     patch_tool = "patch",
     patches = [
-        "//openxla_patches:gpu_nvml.diff",
-        "//openxla_patches:gpu_race_condition.diff",
         "//openxla_patches:count_down.diff",
     ],
     strip_prefix = "xla-" + xla_hash,

--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -1,0 +1,16 @@
+# Debian's python3-dev splits pyconfig.h: the copy pybind11_bazel places in
+# @local_config_python is only a wrapper that includes the real
+# <x86_64-linux-gnu/python3.12/pyconfig.h>, which is never copied and is thus
+# undeclared under strict include validation. Provide the real header here.
+genrule(
+    name = "multiarch_pyconfig_h",
+    outs = ["python_include/x86_64-linux-gnu/python3.12/pyconfig.h"],
+    cmd = "cp -f /usr/include/x86_64-linux-gnu/python3.12/pyconfig.h $@",
+)
+
+cc_library(
+    name = "multiarch_pyconfig",
+    hdrs = [":multiarch_pyconfig_h"],
+    includes = ["python_include"],
+    visibility = ["//visibility:public"],
+)

--- a/bazel/rules_def.bzl
+++ b/bazel/rules_def.bzl
@@ -14,6 +14,8 @@ def ptxla_cc_library(
         deps = deps + [
             "@torch//:headers",
             "@torch//:runtime_headers",
+            "@torch//:source_headers",
+            "//bazel:multiarch_pyconfig",
         ],
         **kwargs
     )

--- a/bazel/rules_def.bzl
+++ b/bazel/rules_def.bzl
@@ -10,11 +10,10 @@ def ptxla_cc_library(
         copts = [],
         **kwargs):
     native.cc_library(
-        copts = copts + ["-isystemexternal/torch"],  # Required for system includes.
+        copts = copts,
         deps = deps + [
             "@torch//:headers",
             "@torch//:runtime_headers",
-            "@torch//:source_headers",
             "//bazel:multiarch_pyconfig",
         ],
         **kwargs
@@ -26,9 +25,7 @@ def ptxla_cc_test(
         **kwargs):
     xla_cc_test(
         linkstatic = True,
-        copts = copts + [
-            "-isystemexternal/torch",  # Required for system includes.
-        ],
+        copts = copts,
         deps = deps + [
             "@pybind11//:pybind11_embed",  # libpython
             "@torch//:headers",

--- a/bazel/torch.BUILD
+++ b/bazel/torch.BUILD
@@ -20,26 +20,6 @@ cc_library(
     strip_include_prefix = "torch/include/torch/csrc/api/include",
 )
 
-# In-tree PyTorch headers (c10/, caffe2/, torch/csrc/, aten/) reached via the
-# `-isystem external/torch` copt are declared by no cc_library, so the strict
-# include validator rejects them. Declare them here; they are hardlinked to
-# torch/include/ by the PyTorch build, so declaring both is inode-safe.
-cc_library(
-    name = "source_headers",
-    hdrs = glob(
-        [
-            "c10/**/*.h",
-            "caffe2/**/*.h",
-            "torch/csrc/**/*.h",
-            "aten/src/**/*.h",
-        ],
-        allow_empty = True,
-    ),
-    # `includes` (not just `hdrs`) is required: it registers external/torch as
-    # the include dir the validator matches these headers against.
-    includes = ["."],
-)
-
 filegroup(
     name = "torchgen_deps",
     srcs = [

--- a/bazel/torch.BUILD
+++ b/bazel/torch.BUILD
@@ -20,6 +20,26 @@ cc_library(
     strip_include_prefix = "torch/include/torch/csrc/api/include",
 )
 
+# In-tree PyTorch headers (c10/, caffe2/, torch/csrc/, aten/) reached via the
+# `-isystem external/torch` copt are declared by no cc_library, so the strict
+# include validator rejects them. Declare them here; they are hardlinked to
+# torch/include/ by the PyTorch build, so declaring both is inode-safe.
+cc_library(
+    name = "source_headers",
+    hdrs = glob(
+        [
+            "c10/**/*.h",
+            "caffe2/**/*.h",
+            "torch/csrc/**/*.h",
+            "aten/src/**/*.h",
+        ],
+        allow_empty = True,
+    ),
+    # `includes` (not just `hdrs`) is required: it registers external/torch as
+    # the include dir the validator matches these headers against.
+    includes = ["."],
+)
+
 filegroup(
     name = "torchgen_deps",
     srcs = [

--- a/codegen/BUILD
+++ b/codegen/BUILD
@@ -1,3 +1,8 @@
+# Use rules_python's py_binary, not the native rule: rules_python substitutes the
+# bootstrap template's %interpreter_args% placeholder, which the native rule
+# leaves in place and crashes this generator with a SyntaxError.
+load("@rules_python//python:py_binary.bzl", "py_binary")
+
 exports_files(["xla_native_functions.yaml"])
 
 # Requires `torchgen` locally, via pip `torch` package or local builds.

--- a/openxla_patches/count_down.diff
+++ b/openxla_patches/count_down.diff
@@ -1,14 +1,17 @@
-diff --git a/xla/backends/cpu/runtime/convolution_thunk_internal.h b/xla/backends/cpu/runtime/convolution_thunk_internal.h
-index 84fed6bb78..9835f12e4e 100644
---- a/xla/backends/cpu/runtime/convolution_thunk_internal.h
-+++ b/xla/backends/cpu/runtime/convolution_thunk_internal.h
-@@ -342,7 +342,8 @@ void EigenGenericConv2D(
-         Eigen::Index start = task_index * task_size;
-         Eigen::Index end = std::min(start + task_size, feature_group_count);
-         for (Eigen::Index i = start; i < end; ++i) {
--          auto on_done = [count_down]() mutable { count_down.CountDown(); };
-+          // auto on_done = [count_down]() mutable { count_down.CountDown(); };
-+          auto on_done = [count_down]() mutable { const_cast<decltype(count_down)*>(&count_down)->CountDown(); };
-           auto [output, convolved] = convolve_group(i);
-           output.device(device, std::move(on_done)) = convolved;
-         }
+diff --git a/xla/backends/cpu/runtime/convolution_lib.h b/xla/backends/cpu/runtime/convolution_lib.h
+--- a/xla/backends/cpu/runtime/convolution_lib.h
++++ b/xla/backends/cpu/runtime/convolution_lib.h
+@@ -414,5 +414,5 @@
+           Eigen::Index end = std::min(start + task_size, feature_group_count);
+           for (Eigen::Index i = start; i < end; ++i) {
+-            auto on_done = [count_down]() mutable { count_down.CountDown(); };
++            auto on_done = [count_down]() mutable { const_cast<decltype(count_down)*>(&count_down)->CountDown(); };
+             auto [output, convolved] = convolve_group(i);
+             output.device(*device, std::move(on_done)) = convolved;
+@@ -574,5 +574,5 @@
+
+     if (device != nullptr) {
+-      auto on_done = [count_down]() mutable { count_down.CountDown(); };
++      auto on_done = [count_down]() mutable { const_cast<decltype(count_down)*>(&count_down)->CountDown(); };
+       output_reshaped.device(*device, std::move(on_done)) = convolved;
+     } else {

--- a/setup.py
+++ b/setup.py
@@ -118,9 +118,9 @@ USE_NIGHTLY = False  # Whether to use nightly or stable libtpu and JAX.
 _libtpu_version = '0.0.18'
 _libtpu_date = '20250617'
 
-_jax_version = '0.7.1'
-_jaxlib_version = '0.7.1'
-_jax_date = '20250617'  # Date for jax and jaxlib.
+_jax_version = '0.11.0'
+_jaxlib_version = '0.11.0'
+_jax_date = '20260716'  # Date for jax and jaxlib.
 
 if USE_NIGHTLY:
   _libtpu_version += f".dev{_libtpu_date}"

--- a/torch_xla/csrc/dl_convertor.cpp
+++ b/torch_xla/csrc/dl_convertor.cpp
@@ -143,7 +143,7 @@ DLManagedTensor* toDLPack(const at::Tensor& input) {
     // AcquireExternalReference may block
     pack->external_reference =
         GetValueOrThrow(pjrt_buffer->AcquireExternalReference());
-    xla::PjRtFuture<> future = pjrt_buffer->GetReadyFuture();
+    xla::Future<> future = pjrt_buffer->GetReadyFuture();
     MaybeThrow(future.Await());
   }
   pack->buffer_reference = pjrt_buffer;

--- a/torch_xla/csrc/helpers.cpp
+++ b/torch_xla/csrc/helpers.cpp
@@ -1076,7 +1076,9 @@ std::vector<xla::HloSharding> XlaHelpers::ExtractInputShardings(
       XLA_CHECK_EQ(index, param_shardings.size());
       param_shardings.push_back(*xla::HloSharding::FromProto(instr.sharding()));
       TF_VLOG(5) << "index = " << index
-                 << " shape = " << xla::Shape(instr.shape()).ToString()
+                 << " shape = "
+                 << GetValueOrThrow(xla::Shape::FromProto(instr.shape()))
+                        .ToString()
                  << " sharding = "
                  << xla::HloSharding::FromProto(instr.sharding())->ToString();
     }

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -1334,7 +1334,7 @@ class PyLoweringContext {
   std::string GetHloJsonText() {
     const xla::HloModuleProto& proto = computation.proto();
     std::string result;
-    google::protobuf::util::MessageToJsonString(proto, &result);
+    XLA_CHECK_OK(google::protobuf::util::MessageToJsonString(proto, &result));
     return result;
   }
 

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -943,11 +943,11 @@ py::dict GetMemoryInfo(const std::string& device_str) {
 
 // Must be called holding GIL as it reads Python objects. Also, Python objects
 // are reference counted; reading py::dict will increase its reference count.
-absl::flat_hash_map<std::string, std::variant<int, std::string>>
+absl::flat_hash_map<std::string, std::variant<bool, int, std::string>>
 ConvertDictToMap(const py::dict& dictionary) {
-  absl::flat_hash_map<std::string, std::variant<int, std::string>> map;
+  absl::flat_hash_map<std::string, std::variant<bool, int, std::string>> map;
   for (const auto& item : dictionary) {
-    std::variant<int, std::string> value;
+    std::variant<bool, int, std::string> value;
     try {
       value = item.second.cast<int>();
     } catch (...) {
@@ -1052,7 +1052,7 @@ void BuildProfilerSubmodule(py::module* m) {
           [](const char* service_addr, const char* logdir, int duration_ms,
              int num_tracing_attempts, int timeout_s, int interval_s,
              py::dict options) {
-            absl::flat_hash_map<std::string, std::variant<int, std::string>>
+            absl::flat_hash_map<std::string, std::variant<bool, int, std::string>>
                 opts = ConvertDictToMap(options);
             std::chrono::seconds sleep_s(interval_s);
             absl::Status status;

--- a/torch_xla/csrc/lowering_context.h
+++ b/torch_xla/csrc/lowering_context.h
@@ -13,6 +13,7 @@
 #include <utility>
 #include <vector>
 
+#include "absl/base/attributes.h"
 #include "absl/status/status.h"
 #include "absl/types/span.h"
 #include "torch_xla/csrc/device.h"
@@ -124,7 +125,7 @@ class LoweringContext : public torch::lazy::LoweringContext {
   };
 
   // Reports an XLA builder error for the given node.
-  TF_ATTRIBUTE_NORETURN void ReportBuilderError(const torch::lazy::Node& node,
+  ABSL_ATTRIBUTE_NORETURN void ReportBuilderError(const torch::lazy::Node& node,
                                                 absl::string_view error_msg);
 
   xla::XlaBuilder builder_;

--- a/torch_xla/csrc/ops/recv.cpp
+++ b/torch_xla/csrc/ops/recv.cpp
@@ -4,6 +4,7 @@
 #include "torch_xla/csrc/ops/infer_output_shape.h"
 #include "torch_xla/csrc/ops/xla_ops.h"
 #include "torch_xla/csrc/runtime/util.h"
+#include "torch_xla/csrc/status.h"
 
 namespace torch_xla {
 namespace ir {
@@ -29,7 +30,7 @@ Recv::Recv(const torch::lazy::Value& token, const xla::Shape& recv_shape,
           [&]() { return NodeOutputShape(token, recv_shape, channel_id); },
           /*num_outputs=*/2,
           torch::lazy::MHash(channel_id, recv_shape.ToString())),
-      recv_shape_(recv_shape.ToProto()),
+      recv_shape_(GetValueOrThrow(xla::Shape::FromProto(recv_shape.ToProto()))),
       channel_id_(channel_id) {}
 
 torch::lazy::NodePtr Recv::Clone(torch::lazy::OpList operands) const {

--- a/torch_xla/csrc/runtime/BUILD
+++ b/torch_xla/csrc/runtime/BUILD
@@ -389,16 +389,41 @@ cc_test(
     ],
 )
 
+# Vendored copy of TSL's platform logging internals (LogMessage, CheckOpString,
+# Check_*Impl, ...). OpenXLA removed these from its public TSL API when it
+# migrated to Abseil logging (openxla/xla#29477); tf_logging.h relies on them,
+# so we carry a self-contained copy under the ::tsl::torch_xla::internal
+# namespace.
+cc_library(
+    name = "tsl_platform_logging",
+    srcs = ["tsl_platform_logging.cpp"],
+    hdrs = ["tsl_platform_logging.h"],
+    deps = [
+        "@xla//xla/tsl/platform:env_time",
+        "@xla//xla/tsl/platform:logging",
+        "@xla//xla/tsl/platform:macros",
+        "@xla//xla/tsl/platform:types",
+        "@com_google_absl//absl/base:core_headers",
+        "@com_google_absl//absl/base:log_severity",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/strings:str_format",
+        "@com_google_absl//absl/strings:string_view",
+    ],
+)
+
 cc_library(
     name = "tf_logging",
     srcs = ["tf_logging.cpp"],
     hdrs = ["tf_logging.h"],
     deps = [
+        ":tsl_platform_logging",
         "//torch_xla/csrc:status",
         "@tsl//tsl/platform:stacktrace",
         "@tsl//tsl/platform:statusor",
         "@xla//xla/service:platform_util",
+        "@com_google_absl//absl/base:core_headers",
         "@com_google_absl//absl/base:log_severity",
+        "@com_google_absl//absl/log:absl_log",
     ],
 )
 

--- a/torch_xla/csrc/runtime/BUILD
+++ b/torch_xla/csrc/runtime/BUILD
@@ -38,9 +38,6 @@ cc_library(
     hdrs = [
         "computation_client.h",
     ],
-    copts = [
-        "-isystemexternal/torch",
-    ],
     deps = [
         ":debug_macros",
         ":env_vars",

--- a/torch_xla/csrc/runtime/BUILD
+++ b/torch_xla/csrc/runtime/BUILD
@@ -133,6 +133,7 @@ cc_library(
         "@xla//xla:shape_util",
         "@xla//xla/hlo/builder:xla_computation",
         "@xla//xla/pjrt:pjrt_client",
+        "@xla//xla/pjrt:pjrt_future",
         "@xla//xla/pjrt/c:pjrt_c_api_gpu_extension_hdrs",
         "@xla//xla/pjrt/c:pjrt_c_api_hdrs",
         "@xla//xla/pjrt/c:pjrt_c_api_wrapper_impl",
@@ -255,7 +256,7 @@ cc_library(
         ":env_vars",
         "//torch_xla/csrc:status",
         "@com_google_absl//absl/base:nullability",
-        "@xla//xla/tsl/distributed_runtime/preemption:preemption_sync_manager",
+        "@xla//xla/pjrt/distributed/preemption:preemption_sync_manager",
         "@xla//xla/pjrt/distributed",
     ],
 )

--- a/torch_xla/csrc/runtime/ifrt_computation_client.cpp
+++ b/torch_xla/csrc/runtime/ifrt_computation_client.cpp
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include "absl/strings/ascii.h"
+#include "absl/strings/str_split.h"
 #include "absl/synchronization/blocking_counter.h"
 #include "absl/types/span.h"
 #include "torch_xla/csrc/runtime/computation_client.h"

--- a/torch_xla/csrc/runtime/ifrt_computation_client.cpp
+++ b/torch_xla/csrc/runtime/ifrt_computation_client.cpp
@@ -87,13 +87,14 @@ torch::lazy::hash_t hash_comp_env(
   if (topology_desc.ok()) {
     // Some backends support a topology description which provides a better
     // view of the specific compilation environment.
-    auto serialized = topology_desc.value()->Serialize();
-    if (serialized.ok()) {
+    auto fingerprint = topology_desc.value()->Fingerprint();
+    if (fingerprint.ok()) {
+      uint64_t fingerprint_value = *fingerprint;
       return torch::lazy::HashCombine(
-          hash,
-          torch::lazy::DataHash(serialized->data(), serialized->length()));
+          hash, torch::lazy::DataHash(&fingerprint_value,
+                                      sizeof(fingerprint_value)));
     }
-    // If serialization fails, fallthrough to the manual approach.
+    // If fingerprinting fails, fallthrough to the manual approach.
   }
   return hash;
 }
@@ -218,7 +219,8 @@ std::vector<ComputationClient::DataPtr> IfrtComputationClient::GetDataShards(
     std::vector<tsl::RCReference<xla::ifrt::Array>> arrays =
         ifrt_data->buffer
             ->DisassembleIntoSingleDeviceArrays(
-                xla::ifrt::ArrayCopySemantics::kAlwaysCopy)
+                xla::ifrt::ArrayCopySemantics::kAlwaysCopy,
+                xla::ifrt::SingleDeviceShardSemantics::kAddressableShards)
             .value();
 
     for (auto array : arrays) {
@@ -306,10 +308,10 @@ std::vector<ComputationClient::DataPtr> IfrtComputationClient::TransferToDevice(
                 // TODO: what is MemoryKind?
                 xla::ifrt::SingleDeviceSharding::Create(
                     ifrt_device, xla::ifrt::MemoryKind()),
+                /*layout=*/nullptr,
                 xla::ifrt::Client::HostBufferSemantics::
                     kImmutableUntilTransferCompletes,
-                [tensor, timed]() { /* frees tensor and timer */ },
-                client_->CreateUserContext())
+                [tensor, timed]() { /* frees tensor and timer */ })
             .value();
 
     ComputationClient::DataPtr data =
@@ -517,10 +519,13 @@ std::vector<ComputationClient::ComputationPtr> IfrtComputationClient::Compile(
     torch_xla::ConvertHloToStableHlo(instance.computation.mutable_proto(),
                                      &mlir_module);
     std::shared_ptr<xla::ifrt::LoadedExecutable> executable =
-        GetValueOrThrow(client_->GetDefaultCompiler()->CompileAndLoad(
-            std::make_unique<xla::ifrt::HloProgram>(mlir_module),
-            std::make_unique<xla::ifrt::XlaCompileOptions>(compile_options,
-                                                           devices_list)));
+        GetValueOrThrow(
+            client_->GetDefaultCompiler()
+                ->CompileAndLoad(
+                    std::make_unique<xla::ifrt::HloProgram>(mlir_module),
+                    std::make_unique<xla::ifrt::XlaCompileOptions>(
+                        compile_options, devices_list))
+                .Await());
     StableHloCompileCounter()->AddValue(1);
 
     const auto& hlo_modules = GetValueOrThrow(executable->GetHloModules());

--- a/torch_xla/csrc/runtime/pjrt_computation_client.cpp
+++ b/torch_xla/csrc/runtime/pjrt_computation_client.cpp
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include "absl/strings/ascii.h"
+#include "absl/strings/str_split.h"
 #include "absl/synchronization/blocking_counter.h"
 #include "absl/types/span.h"
 #include "torch_xla/csrc/runtime/computation_client.h"
@@ -29,6 +30,7 @@
 #include "xla/pjrt/pjrt_c_api_client.h"
 #include "xla/pjrt/pjrt_client.h"
 #include "xla/pjrt/pjrt_executable.h"
+#include "xla/pjrt/pjrt_future.h"
 #include "xla/service/custom_call_target_registry.h"
 #include "xla/shape.h"
 

--- a/torch_xla/csrc/runtime/pjrt_computation_client.cpp
+++ b/torch_xla/csrc/runtime/pjrt_computation_client.cpp
@@ -30,7 +30,7 @@
 #include "xla/pjrt/pjrt_c_api_client.h"
 #include "xla/pjrt/pjrt_client.h"
 #include "xla/pjrt/pjrt_executable.h"
-#include "xla/pjrt/pjrt_future.h"
+#include "xla/future.h"
 #include "xla/service/custom_call_target_registry.h"
 #include "xla/shape.h"
 
@@ -71,11 +71,12 @@ torch::lazy::hash_t hash_comp_env(
   if (topology_desc.ok()) {
     // Some backends support a topology description which provides a better
     // view of the specific compilation environment.
-    auto serialized = topology_desc.value()->Serialize();
-    if (serialized.ok()) {
+    auto topology_proto = topology_desc.value()->ToProto();
+    if (topology_proto.ok()) {
+      std::string serialized = topology_proto->SerializeAsString();
       return torch::lazy::HashCombine(
           hash,
-          torch::lazy::DataHash(serialized->data(), serialized->length()));
+          torch::lazy::DataHash(serialized.data(), serialized.length()));
     }
     // If serialization fails, fallthrough to the manual approach.
   }
@@ -574,7 +575,7 @@ std::vector<xla::Literal> PjRtComputationClient::TransferFromDevice(
     }
   }
 
-  std::vector<xla::PjRtFuture<>> futures;
+  std::vector<xla::Future<>> futures;
   futures.reserve(total_transfers);
   std::vector<xla::Literal> global_literals;
   global_literals.reserve(total_transfers);
@@ -769,7 +770,9 @@ std::vector<ComputationClient::ComputationPtr> PjRtComputationClient::Compile(
       executable = util::RaisePythonValueErrorOnFailure([&] {
         return fake_xla_compile_
                    ? fake_xla_compile_()
-                   : client_->CompileAndLoad(mlir_module, compile_options);
+                   : client_->CompileAndLoad(
+                         xla::MaybeOwningMlirModule(mlir_module),
+                         compile_options);
       });
       StableHloCompileCounter()->AddValue(1);
     } else {
@@ -885,7 +888,6 @@ PjRtComputationClient::ExecuteComputation(
   }
 
   xla::ExecuteOptions execute_options;
-  execute_options.untuple_result = options.explode_tuple;
   execute_options.strict_shape_checking = false;
 
   // Required as of cl/518733871
@@ -896,7 +898,7 @@ PjRtComputationClient::ExecuteComputation(
   TF_VLOG(5) << "ExecuteComputation acquiring PJRT device lock for " << device
              << " Done";
 
-  std::optional<xla::PjRtFuture<>> returned_future;
+  std::optional<xla::Future<>> returned_future;
   std::vector<std::unique_ptr<xla::PjRtBuffer>> results =
       pjrt_computation.executable
           ->ExecuteSharded(buffers, pjrt_device, execute_options,
@@ -979,7 +981,6 @@ PjRtComputationClient::ExecuteReplicated(
   }
 
   xla::ExecuteOptions execute_options;
-  execute_options.untuple_result = options.explode_tuple;
   execute_options.strict_shape_checking = true;
   // TODO(yeounoh) currently only support single-slice execution
   execute_options.multi_slice_config = nullptr;
@@ -996,8 +997,8 @@ PjRtComputationClient::ExecuteReplicated(
   TF_VLOG(5) << "ExecuteReplicated acquiring PJRT device lock for "
              << spmd_device_str << " Done";
 
-  std::optional<std::vector<xla::PjRtFuture<>>> returned_futures =
-      std::vector<xla::PjRtFuture<>>();
+  std::optional<std::vector<xla::Future<>>> returned_futures =
+      std::vector<xla::Future<>>();
   std::vector<std::vector<std::unique_ptr<xla::PjRtBuffer>>> results;
   {
     tsl::profiler::TraceMe activity(
@@ -1193,7 +1194,20 @@ void PjRtComputationClient::RegisterCustomCall(const std::string& fn_name,
   PJRT_Error* error =
       reinterpret_cast<const PJRT_Gpu_Custom_Call*>(next)->custom_call(&args);
   if (error) {
-    XLA_ERROR() << error->status;
+    // PJRT_Error is opaque in the PJRT C API; retrieve its message through the
+    // API and free it rather than reaching into a (no-longer-existent) member.
+    PJRT_Error_Message_Args message_args;
+    message_args.struct_size = PJRT_Error_Message_Args_STRUCT_SIZE;
+    message_args.extension_start = nullptr;
+    message_args.error = error;
+    pjrt_api->PJRT_Error_Message(&message_args);
+    std::string error_message(message_args.message, message_args.message_size);
+    PJRT_Error_Destroy_Args destroy_args;
+    destroy_args.struct_size = PJRT_Error_Destroy_Args_STRUCT_SIZE;
+    destroy_args.extension_start = nullptr;
+    destroy_args.error = error;
+    pjrt_api->PJRT_Error_Destroy(&destroy_args);
+    XLA_ERROR() << error_message;
   }
 }
 

--- a/torch_xla/csrc/runtime/pjrt_computation_client.h
+++ b/torch_xla/csrc/runtime/pjrt_computation_client.h
@@ -115,13 +115,13 @@ class PjRtComputationClient : public ComputationClient {
   absl::StatusOr<xla::PjRtDevice*> LookupAddressableDevice(
       int local_device_id) const override {
     return client_->LookupAddressableDevice(
-        xla::PjRtLocalDeviceId(local_device_id));
+        xla::LocalDeviceId(local_device_id));
   }
 
   std::intptr_t GetCudaStreamForDevice(int local_device_id) const override {
     absl::StatusOr<xla::PjRtDevice*> pjrt_device =
         client_->LookupAddressableDevice(
-            xla::PjRtLocalDeviceId(local_device_id));
+            xla::LocalDeviceId(local_device_id));
     XLA_CHECK(pjrt_device.ok()) << "Failed to get a PjRt device.";
     absl::StatusOr<std::intptr_t> stream =
         pjrt_device.value()->GetStreamForExternalReadyEvents();

--- a/torch_xla/csrc/runtime/pjrt_registry.cpp
+++ b/torch_xla/csrc/runtime/pjrt_registry.cpp
@@ -138,8 +138,11 @@ InitializePjRt(const std::string& device_type) {
     TF_VLOG(1) << "Initializing PjRt CPU client...";
     bool async = sys_util::GetEnvBool(env::kEnvPjrtAsyncCpuClient, true);
     int cpu_device_count = sys_util::GetEnvInt(env::kEnvNumCpu, 1);
+    xla::CpuClientOptions cpu_options;
+    cpu_options.asynchronous = async;
+    cpu_options.cpu_device_count = cpu_device_count;
     XLA_ASSIGN_OR_RETURN(client,
-                         xla::GetPjRtCpuClient(async, cpu_device_count));
+                         xla::GetXlaPjrtCpuClient(std::move(cpu_options)));
   } else if (device_type == "TPU") {
     TF_VLOG(1) << "Initializing TFRT TPU client...";
     // Init the absl logging to avoid the log spam.

--- a/torch_xla/csrc/runtime/profiler.cpp
+++ b/torch_xla/csrc/runtime/profiler.cpp
@@ -74,7 +74,7 @@ std::unique_ptr<TslProfilerSessionWrapper> TslProfilerSessionWrapper::Create() {
 absl::Status Trace(
     const char* service_addr, const char* logdir, int duration_ms,
     int num_tracing_attempts,
-    const absl::flat_hash_map<std::string, std::variant<int, std::string>>&
+    const absl::flat_hash_map<std::string, std::variant<bool, int, std::string>>&
         options) {
   return tsl::profiler::CaptureRemoteTrace(
       service_addr, logdir, /*worker_list=*/"",

--- a/torch_xla/csrc/runtime/profiler.h
+++ b/torch_xla/csrc/runtime/profiler.h
@@ -46,7 +46,7 @@ class TslProfilerSessionWrapper {
 absl::Status Trace(
     const char* service_addr, const char* logdir, int duration_ms,
     int num_tracing_attempts,
-    const absl::flat_hash_map<std::string, std::variant<int, std::string>>&
+    const absl::flat_hash_map<std::string, std::variant<bool, int, std::string>>&
         options);
 
 void RegisterProfilerForPlugin(const PJRT_Api* c_api);

--- a/torch_xla/csrc/runtime/tf_logging.h
+++ b/torch_xla/csrc/runtime/tf_logging.h
@@ -3,32 +3,30 @@
 
 #include <sstream>
 
-#include "absl/base/log_severity.h"
-#include "tsl/platform/logging.h"
+#include "absl/base/optimization.h"
+#include "absl/log/absl_log.h"
+
+#include "torch_xla/csrc/runtime/tsl_platform_logging.h"
 
 namespace torch_xla {
 namespace runtime {
 namespace internal {
 
-// It happens that Caffe defined the same exact Google macros, hiding the TF
-// ones, and making log messages disappear.
-// Unfortunately to get those back, we have to poke through the TF
-// implementaiton of them.
-#define TF_LOG(severity) _TF_LOG_##severity
-
-#define TF_VLOG_IS_ON(lvl)                                           \
-  (([](int level, const char* fname) {                               \
-    static const bool vmodule_activated =                            \
-        ::tsl::internal::LogMessage::VmoduleActivated(fname, level); \
-    return vmodule_activated;                                        \
-  })(lvl, __FILE__))
-
-#define TF_VLOG(level)                                    \
-  TF_PREDICT_TRUE(!TF_VLOG_IS_ON(level))                  \
-  ? (void)0                                               \
-  : ::tsl::internal::Voidifier() &                        \
-          ::tsl::internal::LogMessage(__FILE__, __LINE__, \
-                                      absl::LogSeverity::kInfo)
+// TODO: replace all TF_*LOG macro calls with ABSL_*LOG()
+//
+// Why are we using Abseil logging, now?
+// =====================================
+// Ref: https://github.com/openxla/xla/pull/29477
+//
+// OpenXLA removed their internal logging in favor of Abseil.
+//
+// Why do we have the `TF_` prefix?
+// ================================
+// Ref: https://github.com/pytorch/xla/pull/34
+//
+// So as not to clash with C10 definition.
+#define TF_LOG(severity) ABSL_LOG(severity)
+#define TF_VLOG(level) ABSL_VLOG(level)
 
 struct ErrorSink : public std::basic_ostringstream<char> {};
 
@@ -39,7 +37,7 @@ class ErrorGenerator {
   // Use a dummy & operator as it has lower precedence WRT the streaming
   // operator, and hence allows collecting user error messages before we finally
   // throw.
-  TF_ATTRIBUTE_NORETURN void operator&(
+  ABSL_ATTRIBUTE_NORETURN void operator&(
       const std::basic_ostream<char>& oss) const;
 
  private:
@@ -55,10 +53,12 @@ class ErrorGenerator {
   while (TF_PREDICT_FALSE(!(condition))) \
   TF_ERROR_STREAM() << "Check failed: " #condition ": "
 
-#define TF_CHECK_OP_LOG(name, op, val1, val2)                                  \
-  while (::tsl::internal::CheckOpString _result{::tsl::internal::name##Impl(   \
-      ::tsl::internal::GetReferenceableValue(val1),                            \
-      ::tsl::internal::GetReferenceableValue(val2), #val1 " " #op " " #val2)}) \
+#define TF_CHECK_OP_LOG(name, op, val1, val2)                      \
+  while (::tsl::torch_xla::internal::CheckOpString _result{        \
+      ::tsl::torch_xla::internal::name##Impl(                      \
+          ::tsl::torch_xla::internal::GetReferenceableValue(val1), \
+          ::tsl::torch_xla::internal::GetReferenceableValue(val2), \
+          #val1 " " #op " " #val2)})                               \
   TF_ERROR_STREAM() << *(_result.str_)
 
 #define TF_CHECK_OP(name, op, val1, val2) TF_CHECK_OP_LOG(name, op, val1, val2)
@@ -75,9 +75,17 @@ class ErrorGenerator {
 #define TF_CHECK_GE(val1, val2) TF_CHECK_LE(val2, val1)
 #define TF_CHECK_GT(val1, val2) TF_CHECK_LT(val2, val1)
 
-#undef TF_CHECK_OK
-#define TF_CHECK_OK(val) TF_DO_CHECK_OK(val, FATAL)
-#define TF_CHECK_NOTNULL(val) TF_CHECK(val != nullptr)
+// Streamable, single-evaluation status check. The argument is evaluated exactly
+// once (some call sites pass function calls, e.g. XLA_CHECK_OK(Fn())), and
+// callers may append context with operator<<. Backs XLA_CHECK_OK (see
+// debug_macros.h). The loop body is [[noreturn]] (ErrorGenerator throws), so it
+// runs at most once.
+#define TF_CHECK_OK(val)                              \
+  for (auto&& _tf_check_status = (val);               \
+       ABSL_PREDICT_FALSE(!(_tf_check_status).ok());) \
+  TF_ERROR_STREAM() << "Check failed: " #val " is not OK: "
+
+#define TF_CHECK_NOTNULL(val) TF_CHECK((val) != nullptr)
 
 }  // namespace internal
 }  // namespace runtime

--- a/torch_xla/csrc/runtime/tsl_platform_logging.cpp
+++ b/torch_xla/csrc/runtime/tsl_platform_logging.cpp
@@ -1,0 +1,579 @@
+/* Copyright 2015 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+/*
+ * This file was copied from the OpenXLA repository
+ * (https://github.com/openxla/xla), before it was deleted.
+ *
+ * Commit: 20358a12f26199d016e6e690fe31a4a0a141226e
+ * Date: 2025-08-26
+ */
+
+#include "torch_xla/csrc/runtime/tsl_platform_logging.h"
+
+#include <atomic>
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <limits>
+#include <ostream>
+#include <vector>
+
+// TODO(b/142492876): Avoid depending on absl internal.
+#include "absl/base/internal/cycleclock.h"
+#include "absl/base/internal/sysinfo.h"
+#include "absl/base/log_severity.h"
+#include "absl/base/optimization.h"
+#include "absl/container/flat_hash_map.h"
+#include "absl/strings/numbers.h"
+#include "absl/strings/str_format.h"
+#include "absl/strings/string_view.h"
+#include "absl/synchronization/mutex.h"
+#include "xla/tsl/platform/env_time.h"
+#include "xla/tsl/platform/types.h"
+
+#if defined(PLATFORM_POSIX_ANDROID)
+#include <android/log.h>
+
+#include <iostream>
+#include <sstream>
+#endif
+
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#include <algorithm>
+#include <queue>
+
+namespace tsl {
+
+namespace torch_xla {
+
+namespace internal {
+namespace {
+
+// This is an internal singleton class that manages the log sinks. It allows
+// adding and removing the log sinks, as well as handling sending log messages
+// to all the registered log sinks.
+class TFLogSinks {
+ public:
+  // Gets the TFLogSinks instance. This is the entry point for using this class.
+  static TFLogSinks& Instance();
+
+  // Adds a log sink. The sink argument must not be a nullptr. TFLogSinks
+  // takes ownership of the pointer, the user must not free the pointer.
+  // The pointer will remain valid until the application terminates or
+  // until TFLogSinks::Remove is called for the same pointer value.
+  void Add(TFLogSink* sink);
+
+  // Removes a log sink. This will also erase the sink object. The pointer
+  // to the sink becomes invalid after this call.
+  void Remove(TFLogSink* sink);
+
+  // Gets the currently registered log sinks.
+  std::vector<TFLogSink*> GetSinks() const;
+
+  // Sends a log message to all registered log sinks.
+  //
+  // If there are no log sinks are registered:
+  //
+  // NO_DEFAULT_LOGGER is defined:
+  // Up to 128 messages will be queued until a log sink is added.
+  // The queue will then be logged to the first added log sink.
+  //
+  // NO_DEFAULT_LOGGER is not defined:
+  // The messages will be logged using the default logger. The default logger
+  // will log to stdout on all platforms except for Android. On Androit the
+  // default Android logger will be used.
+  void Send(const TFLogEntry& entry);
+
+ private:
+  TFLogSinks();
+  void SendToSink(TFLogSink& sink, const TFLogEntry& entry);
+
+  std::queue<TFLogEntry> log_entry_queue_;
+  static const size_t kMaxLogEntryQueueSize = 128;
+
+  mutable absl::Mutex mutex_;
+  std::vector<TFLogSink*> sinks_;
+};
+
+TFLogSinks::TFLogSinks() {
+#ifndef NO_DEFAULT_LOGGER
+  static TFDefaultLogSink* const default_sink = new TFDefaultLogSink();
+  sinks_.push_back(default_sink);
+#endif
+}
+
+TFLogSinks& TFLogSinks::Instance() {
+  static TFLogSinks* const instance = new TFLogSinks();
+  return *instance;
+}
+
+void TFLogSinks::Add(TFLogSink* sink) {
+  assert(sink != nullptr && "The sink must not be a nullptr");
+
+  absl::MutexLock lock(&mutex_);
+  sinks_.push_back(sink);
+
+  // If this is the only sink log all the queued up messages to this sink
+  if (sinks_.size() == 1) {
+    while (!log_entry_queue_.empty()) {
+      for (const auto& sink : sinks_) {
+        SendToSink(*sink, log_entry_queue_.front());
+      }
+      log_entry_queue_.pop();
+    }
+  }
+}
+
+void TFLogSinks::Remove(TFLogSink* sink) {
+  assert(sink != nullptr && "The sink must not be a nullptr");
+
+  absl::MutexLock lock(&mutex_);
+  auto it = std::find(sinks_.begin(), sinks_.end(), sink);
+  if (it != sinks_.end()) sinks_.erase(it);
+}
+
+std::vector<TFLogSink*> TFLogSinks::GetSinks() const {
+  absl::MutexLock lock(&mutex_);
+  return sinks_;
+}
+
+void TFLogSinks::Send(const TFLogEntry& entry) {
+  absl::MutexLock lock(&mutex_);
+
+  // If we don't have any sinks registered, queue them up
+  if (sinks_.empty()) {
+    // If we've exceeded the maximum queue size, drop the oldest entries
+    while (log_entry_queue_.size() >= kMaxLogEntryQueueSize) {
+      log_entry_queue_.pop();
+    }
+    log_entry_queue_.push(entry);
+    return;
+  }
+
+  // If we have items in the queue, push them out first
+  while (!log_entry_queue_.empty()) {
+    for (const auto& sink : sinks_) {
+      SendToSink(*sink, log_entry_queue_.front());
+    }
+    log_entry_queue_.pop();
+  }
+
+  // ... and now we can log the current log entry
+  for (const auto& sink : sinks_) {
+    SendToSink(*sink, entry);
+  }
+}
+
+void TFLogSinks::SendToSink(TFLogSink& sink, const TFLogEntry& entry) {
+  sink.Send(entry);
+  sink.WaitTillSent();
+}
+
+// A class for managing the text file to which VLOG output is written.
+// If the environment variable TF_CPP_VLOG_FILENAME is set, all VLOG
+// calls are redirected from stderr to a file with corresponding name.
+class VlogFileMgr {
+ public:
+  // Determines if the env variable is set and if necessary
+  // opens the file for write access.
+  VlogFileMgr();
+  // Closes the file.
+  ~VlogFileMgr();
+  // Returns either a pointer to the file or stderr.
+  FILE* FilePtr() const;
+
+ private:
+  FILE* vlog_file_ptr;
+  char* vlog_file_name;
+};
+
+VlogFileMgr::VlogFileMgr() {
+  vlog_file_name = getenv("TF_CPP_VLOG_FILENAME");
+  vlog_file_ptr =
+      vlog_file_name == nullptr ? nullptr : fopen(vlog_file_name, "w");
+
+  if (vlog_file_ptr == nullptr) {
+    vlog_file_ptr = stderr;
+  }
+}
+
+VlogFileMgr::~VlogFileMgr() {
+  if (vlog_file_ptr != stderr) {
+    fclose(vlog_file_ptr);
+  }
+}
+
+FILE* VlogFileMgr::FilePtr() const { return vlog_file_ptr; }
+
+int ParseInteger(absl::string_view str) {
+  int level;
+  if (!absl::SimpleAtoi(str, &level)) {
+    return 0;
+  }
+  return level;
+}
+
+// Parse log level (int64) from environment variable (char*)
+int64_t LogLevelStrToInt(const char* tf_env_var_val) {
+  if (tf_env_var_val == nullptr) {
+    return 0;
+  }
+  return ParseInteger(tf_env_var_val);
+}
+
+using VmoduleMap = absl::flat_hash_map<absl::string_view, int>;
+
+// Returns a mapping from module name to VLOG level, derived from the
+// TF_CPP_VMODULE environment variable; ownership is transferred to the caller.
+VmoduleMap* VmodulesMapFromEnv() {
+  // The value of the env var is supposed to be of the form:
+  //    "foo=1,bar=2,baz=3"
+  const char* env = getenv("TF_CPP_VMODULE");
+  if (env == nullptr) {
+    // If there is no TF_CPP_VMODULE configuration (most common case), return
+    // nullptr so that the ShouldVlogModule() API can fast bail out of it.
+    return nullptr;
+  }
+  // The memory returned by getenv() can be invalidated by following getenv() or
+  // setenv() calls. And since we keep references to it in the VmoduleMap in
+  // form of StringData objects, make a copy of it.
+  const char* env_data = strdup(env);
+  absl::string_view env_view(env_data);
+  VmoduleMap* result = new VmoduleMap();
+  while (!env_view.empty()) {
+    size_t eq_pos = env_view.find('=');
+    if (eq_pos == absl::string_view::npos) {
+      break;
+    }
+    absl::string_view module_name = env_view.substr(0, eq_pos);
+    env_view.remove_prefix(eq_pos + 1);
+
+    // Comma either points at the next comma delimiter, or at a null terminator.
+    // We check that the integer we parse ends at this delimiter.
+    size_t level_end_pos = env_view.find(',');
+    absl::string_view level_str = env_view.substr(0, level_end_pos);
+    (*result)[module_name] = ParseInteger(level_str);
+    if (level_end_pos != absl::string_view::npos) {
+      env_view.remove_prefix(level_end_pos + 1);
+    }
+  }
+  return result;
+}
+
+bool EmitThreadIdFromEnv() {
+  const char* tf_env_var_val = getenv("TF_CPP_LOG_THREAD_ID");
+  return tf_env_var_val == nullptr ? false : ParseInteger(tf_env_var_val) != 0;
+}
+
+}  // namespace
+
+absl::LogSeverityAtLeast MinLogLevelFromEnv() {
+  // We don't want to print logs during fuzzing as that would slow fuzzing down
+  // by almost 2x. So, if we are in fuzzing mode (not just running a test), we
+  // return a value so that nothing is actually printed. Since LOG uses >=
+  // (see ~LogMessage in this file) to see if log messages need to be printed,
+  // the value we're interested on to disable printing is the maximum severity.
+  // See also http://llvm.org/docs/LibFuzzer.html#fuzzer-friendly-build-mode
+#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+  return absl::LogSeverityAtLeast::kInfinity;
+#else
+  const char* tf_env_var_val = getenv("TF_CPP_MIN_LOG_LEVEL");
+  return static_cast<absl::LogSeverityAtLeast>(
+      LogLevelStrToInt(tf_env_var_val));
+#endif
+}
+
+int MaxVLogLevelFromEnv() {
+  // We don't want to print logs during fuzzing as that would slow fuzzing down
+  // by almost 2x. So, if we are in fuzzing mode (not just running a test), we
+  // return a value so that nothing is actually printed. Since VLOG uses <=
+  // (see VLOG_IS_ON in logging.h) to see if log messages need to be printed,
+  // the value we're interested on to disable printing is 0.
+  // See also http://llvm.org/docs/LibFuzzer.html#fuzzer-friendly-build-mode
+#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+  return 0;
+#else
+  const char* tf_env_var_val = getenv("TF_CPP_MAX_VLOG_LEVEL");
+  return LogLevelStrToInt(tf_env_var_val);
+#endif
+}
+
+LogMessage::LogMessage(const char* fname, int line, absl::LogSeverity severity)
+    : fname_(fname), line_(line), severity_(severity) {}
+
+LogMessage& LogMessage::AtLocation(absl::string_view fname, int line) {
+  fname_ = fname;
+  line_ = line;
+  return *this;
+}
+
+LogMessage::~LogMessage() {
+  // Read the min log level once during the first call to logging.
+  static absl::LogSeverityAtLeast min_log_level = MinLogLevelFromEnv();
+  if (severity_ >= min_log_level) {
+    GenerateLogMessage();
+  }
+}
+
+void LogMessage::GenerateLogMessage() {
+  TFLogSinks::Instance().Send(TFLogEntry(severity_, fname_, line_, str()));
+}
+
+int LogMessage::MaxVLogLevel() {
+  static int max_vlog_level = MaxVLogLevelFromEnv();
+  return max_vlog_level;
+}
+
+bool LogMessage::VmoduleActivated(const char* fname, int level) {
+  if (level <= MaxVLogLevel()) {
+    return true;
+  }
+  static VmoduleMap* vmodules = VmodulesMapFromEnv();
+  if (ABSL_PREDICT_TRUE(vmodules == nullptr)) {
+    return false;
+  }
+  absl::string_view module(fname);
+  if (size_t last_slash = module.rfind('/');
+      last_slash != absl::string_view::npos) {
+    module.remove_prefix(last_slash + 1);
+  }
+  if (size_t dot_after = module.find('.');
+      dot_after != absl::string_view::npos) {
+    module.remove_suffix(module.size() - dot_after);
+  }
+  auto it = vmodules->find(module);
+  return it != vmodules->end() && it->second >= level;
+}
+
+LogMessageFatal::LogMessageFatal(const char* file, int line)
+    : LogMessage(file, line, absl::LogSeverity::kFatal) {}
+LogMessageFatal::~LogMessageFatal() {
+  // abort() ensures we don't return (we promised we would not via
+  // ATTRIBUTE_NORETURN).
+  GenerateLogMessage();
+  abort();
+}
+
+template <>
+void MakeCheckOpValueString(std::ostream* os, const char& v) {
+  if (v >= 32 && v <= 126) {
+    (*os) << "'" << v << "'";
+  } else {
+    (*os) << "char value " << static_cast<int16>(v);
+  }
+}
+
+template <>
+void MakeCheckOpValueString(std::ostream* os, const signed char& v) {
+  if (v >= 32 && v <= 126) {
+    (*os) << "'" << v << "'";
+  } else {
+    (*os) << "signed char value " << static_cast<int16>(v);
+  }
+}
+
+template <>
+void MakeCheckOpValueString(std::ostream* os, const unsigned char& v) {
+  if (v >= 32 && v <= 126) {
+    (*os) << "'" << v << "'";
+  } else {
+    (*os) << "unsigned char value " << static_cast<uint16>(v);
+  }
+}
+
+template <>
+void MakeCheckOpValueString(std::ostream* os, const std::nullptr_t& v) {
+  (*os) << "nullptr";
+}
+
+CheckOpMessageBuilder::CheckOpMessageBuilder(const char* exprtext)
+    : stream_(new std::ostringstream) {
+  *stream_ << "Check failed: " << exprtext << " (";
+}
+
+CheckOpMessageBuilder::~CheckOpMessageBuilder() { delete stream_; }
+
+std::ostream* CheckOpMessageBuilder::ForVar2() {
+  *stream_ << " vs. ";
+  return stream_;
+}
+
+string* CheckOpMessageBuilder::NewString() {
+  *stream_ << ")";
+  return new string(stream_->str());
+}
+
+namespace {
+// The following code behaves like AtomicStatsCounter::LossyAdd() for
+// speed since it is fine to lose occasional updates.
+// Returns old value of *counter.
+uint32 LossyIncrement(std::atomic<uint32>* counter) {
+  const uint32 value = counter->load(std::memory_order_relaxed);
+  counter->store(value + 1, std::memory_order_relaxed);
+  return value;
+}
+}  // namespace
+
+bool LogEveryNState::ShouldLog(int n) {
+  return n != 0 && (LossyIncrement(&counter_) % n) == 0;
+}
+
+bool LogFirstNState::ShouldLog(int n) {
+  const int counter_value =
+      static_cast<int>(counter_.load(std::memory_order_relaxed));
+  if (counter_value < n) {
+    counter_.store(counter_value + 1, std::memory_order_relaxed);
+    return true;
+  }
+  return false;
+}
+
+bool LogEveryPow2State::ShouldLog(int ignored) {
+  const uint32 new_value = LossyIncrement(&counter_) + 1;
+  return (new_value & (new_value - 1)) == 0;
+}
+
+bool LogEveryNSecState::ShouldLog(double seconds) {
+  LossyIncrement(&counter_);
+  const int64_t now_cycles = absl::base_internal::CycleClock::Now();
+  int64_t next_cycles = next_log_time_cycles_.load(std::memory_order_relaxed);
+  do {
+    if (now_cycles <= next_cycles) return false;
+  } while (!next_log_time_cycles_.compare_exchange_weak(
+      next_cycles,
+      now_cycles + seconds * absl::base_internal::CycleClock::Frequency(),
+      std::memory_order_relaxed, std::memory_order_relaxed));
+  return true;
+}
+
+}  // namespace internal
+
+void TFAddLogSink(TFLogSink* sink) {
+  internal::TFLogSinks::Instance().Add(sink);
+}
+
+void TFRemoveLogSink(TFLogSink* sink) {
+  internal::TFLogSinks::Instance().Remove(sink);
+}
+
+std::vector<TFLogSink*> TFGetLogSinks() {
+  return internal::TFLogSinks::Instance().GetSinks();
+}
+
+void TFDefaultLogSink::Send(const TFLogEntry& entry) {
+#ifdef PLATFORM_POSIX_ANDROID
+  int android_log_level;
+  switch (entry.log_severity()) {
+    case absl::LogSeverity::kInfo:
+      android_log_level = ANDROID_LOG_INFO;
+      break;
+    case absl::LogSeverity::kWarning:
+      android_log_level = ANDROID_LOG_WARN;
+      break;
+    case absl::LogSeverity::kError:
+      android_log_level = ANDROID_LOG_ERROR;
+      break;
+    case absl::LogSeverity::kFatal:
+      android_log_level = ANDROID_LOG_FATAL;
+      break;
+    default:
+      if (entry.log_severity() < absl::LogSeverity::kInfo) {
+        android_log_level = ANDROID_LOG_VERBOSE;
+      } else {
+        android_log_level = ANDROID_LOG_ERROR;
+      }
+      break;
+  }
+
+  std::stringstream ss;
+  const auto& fname = entry.FName();
+  auto pos = fname.find("/");
+  ss << (pos != std::string::npos ? fname.substr(pos + 1) : fname) << ":"
+     << entry.Line() << " " << entry.ToString();
+  __android_log_write(android_log_level, "native", ss.str().c_str());
+
+  // Also log to stderr (for standalone Android apps).
+  // Don't use 'std::cerr' since it crashes on Android.
+  fprintf(stderr, "native : %s\n", ss.str().c_str());
+
+  // Android logging at level FATAL does not terminate execution, so abort()
+  // is still required to stop the program.
+  if (entry.log_severity() == absl::LogSeverity::kFatal) {
+    abort();
+  }
+#else  // PLATFORM_POSIX_ANDROID
+  static const internal::VlogFileMgr vlog_file;
+  static bool log_thread_id = internal::EmitThreadIdFromEnv();
+  uint64_t now_micros = EnvTime::NowMicros();
+  time_t now_seconds = static_cast<time_t>(now_micros / 1000000);
+  int32_t micros_remainder = static_cast<int32_t>(now_micros % 1000000);
+  const size_t time_buffer_size = 30;
+  char time_buffer[time_buffer_size];
+  struct tm* tp;
+#if defined(__linux__) || defined(__APPLE__)
+  struct tm now_tm;
+  tp = localtime_r(&now_seconds, &now_tm);
+#else
+  tp = localtime(&now_seconds);  // NOLINT(runtime/threadsafe_fn)
+#endif
+  strftime(time_buffer, time_buffer_size, "%Y-%m-%d %H:%M:%S", tp);
+  uint64_t tid = absl::base_internal::GetTID();
+  constexpr size_t kTidBufferSize =
+      (1 + std::numeric_limits<uint64_t>::digits10 + 1);
+  char tid_buffer[kTidBufferSize] = "";
+  if (log_thread_id) {
+    absl::SNPrintF(tid_buffer, sizeof(tid_buffer), " %7u", tid);
+  }
+
+  char sev;
+  switch (entry.log_severity()) {
+    case absl::LogSeverity::kInfo:
+      sev = 'I';
+      break;
+
+    case absl::LogSeverity::kWarning:
+      sev = 'W';
+      break;
+
+    case absl::LogSeverity::kError:
+      sev = 'E';
+      break;
+
+    case absl::LogSeverity::kFatal:
+      sev = 'F';
+      break;
+
+    default:
+      assert(false && "Unknown logging severity");
+      sev = '?';
+      break;
+  }
+
+  absl::FPrintF(vlog_file.FilePtr(), "%s.%06d: %c%s %s:%d] %s\n", time_buffer,
+                micros_remainder, sev, tid_buffer, entry.FName().c_str(),
+                entry.Line(), entry.ToString().c_str());
+  fflush(vlog_file.FilePtr());  // Ensure logs are written immediately.
+#endif  // PLATFORM_POSIX_ANDROID
+}
+
+void UpdateLogVerbosityIfDefined(const char* env_var) {}
+
+}  // namespace torch_xla
+}  // namespace tsl

--- a/torch_xla/csrc/runtime/tsl_platform_logging.h
+++ b/torch_xla/csrc/runtime/tsl_platform_logging.h
@@ -1,0 +1,684 @@
+/* Copyright 2015 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+/*
+ * This file was copied from the OpenXLA repository
+ * (https://github.com/openxla/xla), before it was deleted.
+ *
+ * Commit: 20358a12f26199d016e6e690fe31a4a0a141226e
+ * Date: 2025-08-26
+ */
+
+#if defined(_WIN32)
+// prevent compile error because MSVC doesn't realize in debug build that
+// LOG(FATAL) finally invokes abort()
+#pragma warning(disable : 4716)
+#endif  // _WIN32
+
+#ifndef XLA_TORCH_XLA_CSRC_RUNTIME_TSL_PLATFORM_LOGGING_H_
+#define XLA_TORCH_XLA_CSRC_RUNTIME_TSL_PLATFORM_LOGGING_H_
+
+// IWYU pragma: private, include "xla/tsl/platform/logging.h"
+// IWYU pragma: friend third_party/tensorflow/compiler/xla/tsl/platform/logging.h
+
+#include <atomic>
+#include <limits>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "absl/base/log_severity.h"
+#include "absl/strings/string_view.h"
+#include "xla/tsl/platform/logging.h"
+#include "xla/tsl/platform/macros.h"
+#include "xla/tsl/platform/types.h"
+
+/*
+ * Do not undef.
+ *
+ * // TODO(mrry): Prevent this Windows.h #define from leaking out of our
+ * headers. #undef ERROR
+ *
+ * // Undef everything in case we're being mixed with some other Google library
+ * // which already defined them itself.  Presumably all Google libraries will
+ * // support the same syntax for these so it should not be a big deal if they
+ * // end up using our definitions instead.
+ * #undef LOG
+ * #undef LOG_EVERY_N
+ * #undef LOG_FIRST_N
+ * #undef LOG_EVERY_POW_2
+ * #undef LOG_EVERY_N_SEC
+ * #undef VLOG
+ *
+ * #undef CHECK
+ * #undef CHECK_EQ
+ * #undef CHECK_NE
+ * #undef CHECK_LT
+ * #undef CHECK_LE
+ * #undef CHECK_GT
+ * #undef CHECK_GE
+ *
+ * #undef DCHECK
+ * #undef DCHECK_EQ
+ * #undef DCHECK_NE
+ * #undef DCHECK_LT
+ * #undef DCHECK_LE
+ * #undef DCHECK_GT
+ * #undef DCHECK_GE
+ *
+ * #undef QCHECK
+ * #undef QCHECK_EQ
+ * #undef QCHECK_NE
+ * #undef QCHECK_LT
+ * #undef QCHECK_LE
+ * #undef QCHECK_GT
+ * #undef QCHECK_GE
+ *
+ * #undef PCHECK
+ *
+ */
+
+namespace tsl {
+
+namespace torch_xla {
+
+namespace internal {
+
+class LogMessage : public std::basic_ostringstream<char> {
+ public:
+  LogMessage(const char* fname, int line, absl::LogSeverity severity);
+  ~LogMessage() override;
+
+  // Change the location of the log message.
+  LogMessage& AtLocation(absl::string_view fname, int line);
+
+  // Returns the maximum log level for VLOG statements.
+  // E.g., if MaxVLogLevel() is 2, then VLOG(2) statements will produce output,
+  // but VLOG(3) will not. Defaults to 0.
+  static int MaxVLogLevel();
+
+  // Returns whether VLOG level lvl is activated for the file fname.
+  //
+  // E.g. if the environment variable TF_CPP_VMODULE contains foo=3 and fname is
+  // foo.cc and lvl is <= 3, this will return true. It will also return true if
+  // the level is lower or equal to TF_CPP_MAX_VLOG_LEVEL (default zero).
+  //
+  // It is expected that the result of this query will be cached in the VLOG-ing
+  // call site to avoid repeated lookups. This routine performs a hash-map
+  // access against the VLOG-ing specification provided by the env var.
+  static bool VmoduleActivated(const char* fname, int level);
+
+ protected:
+  void GenerateLogMessage();
+
+ private:
+  absl::string_view fname_;
+  int line_;
+  absl::LogSeverity severity_;
+};
+
+// Uses the lower operator & precedence to voidify a LogMessage reference, so
+// that the ternary VLOG() implementation is balanced, type wise.
+struct Voidifier {
+  template <typename T>
+  void operator&(const T&) const {}
+};
+
+// LogMessageFatal ensures the process will exit in failure after
+// logging this message.
+class LogMessageFatal : public LogMessage {
+ public:
+  LogMessageFatal(const char* file, int line) ABSL_ATTRIBUTE_COLD;
+  ABSL_ATTRIBUTE_NORETURN ~LogMessageFatal() override;
+};
+
+// LogMessageNull supports the DVLOG macro by simply dropping any log messages.
+class LogMessageNull : public std::basic_ostringstream<char> {
+ public:
+  LogMessageNull() = default;
+  ~LogMessageNull() override {}
+};
+
+#define _TF_LOG_INFO                                         \
+  ::tsl::torch_xla::internal::LogMessage(__FILE__, __LINE__, \
+                                         absl::LogSeverity::kInfo)
+#define _TF_LOG_WARNING                                      \
+  ::tsl::torch_xla::internal::LogMessage(__FILE__, __LINE__, \
+                                         absl::LogSeverity::kWarning)
+#define _TF_LOG_ERROR                                        \
+  ::tsl::torch_xla::internal::LogMessage(__FILE__, __LINE__, \
+                                         absl::LogSeverity::kError)
+#define _TF_LOG_FATAL \
+  ::tsl::torch_xla::internal::LogMessageFatal(__FILE__, __LINE__)
+
+#define _TF_LOG_QFATAL _TF_LOG_FATAL
+
+#ifdef NDEBUG
+#define _TF_LOG_DFATAL _TF_LOG_ERROR
+#else
+#define _TF_LOG_DFATAL _TF_LOG_FATAL
+#endif
+
+/*
+ * Avoiding duplicated macro.
+ *
+ * #define LOG(severity) _TF_LOG_##severity
+ *
+ *
+ *
+ * #ifdef IS_MOBILE_PLATFORM
+ *
+ * // Turn VLOG off when under mobile devices for considerations of binary size.
+ * #define VLOG_IS_ON(lvl) ((lvl) <= 0)
+ *
+ * #else
+ *
+ * // Otherwise, set TF_CPP_MAX_VLOG_LEVEL environment to update minimum log
+ * level
+ * // of VLOG, or TF_CPP_VMODULE to set the minimum log level for individual
+ * // translation units.
+ * #define VLOG_IS_ON(lvl)                                              \
+ *   (([](int level, const char* fname) {                               \
+ *     static const bool vmodule_activated =                            \
+ *         ::tsl::torch_xla::internal::LogMessage::VmoduleActivated(fname,
+ * level); \
+ *     return vmodule_activated;                                        \
+ *   })(lvl, __FILE__))
+ *
+ * #endif
+ *
+ * #define VLOG(level)                                       \
+ *   TF_PREDICT_TRUE(!VLOG_IS_ON(level))                     \
+ *   ? (void)0                                               \
+ *   : ::tsl::torch_xla::internal::Voidifier() &                        \
+ *           ::tsl::torch_xla::internal::LogMessage(__FILE__, __LINE__, \
+ *                                       absl::LogSeverity::kInfo)
+ *
+ * // `DVLOG` behaves like `VLOG` in debug mode (i.e. `#ifndef NDEBUG`).
+ * // Otherwise, it compiles away and does nothing.
+ * #ifndef NDEBUG
+ * #define DVLOG VLOG
+ * #else
+ * #define DVLOG(verbose_level) \
+ *   while (false && (verbose_level) > 0)
+ * ::tsl::torch_xla::internal::LogMessageNull() #endif
+ *
+ */
+
+class LogEveryNState {
+ public:
+  bool ShouldLog(int n);
+  uint32_t counter() { return counter_.load(std::memory_order_relaxed); }
+
+ private:
+  std::atomic<uint32> counter_{0};
+};
+
+class LogFirstNState {
+ public:
+  bool ShouldLog(int n);
+  uint32 counter() { return counter_.load(std::memory_order_relaxed); }
+
+ private:
+  std::atomic<uint32> counter_{0};
+};
+
+class LogEveryPow2State {
+ public:
+  bool ShouldLog(int ignored);
+  uint32 counter() { return counter_.load(std::memory_order_relaxed); }
+
+ private:
+  std::atomic<uint32> counter_{0};
+};
+
+class LogEveryNSecState {
+ public:
+  bool ShouldLog(double seconds);
+  uint32 counter() { return counter_.load(std::memory_order_relaxed); }
+
+ private:
+  std::atomic<uint32> counter_{0};
+  // Cycle count according to CycleClock that we should next log at.
+  std::atomic<int64_t> next_log_time_cycles_{0};
+};
+
+/*
+ * Avoiding duplicated macro.
+ * // This macro has a lot going on!
+ * //
+ * // * A local static (`logging_internal_stateful_condition_state`) is
+ * //   declared in a scope such that each `LOG_EVERY_N` (etc.) line has its own
+ * //   state.
+ * // * `COUNTER`, the third variable, is used to support `<< COUNTER`. It is
+ * not
+ * //   mangled, so shadowing can be a problem, albeit more of a
+ * //   shoot-yourself-in-the-foot one.  Don't name your variables `COUNTER`.
+ * // * A single for loop can declare state and also test
+ * //   `condition && state.ShouldLog()`, but there's no way to constrain it to
+ * run
+ * //   only once (or not at all) without declaring another variable.  The outer
+ * //   for-loop declares this variable (`do_log`).
+ * // * Using for loops instead of if statements means there's no risk of an
+ * //   ambiguous dangling else statement.
+ * #define LOGGING_INTERNAL_STATEFUL_CONDITION(kind, condition, arg)   \
+ *   for (bool logging_internal_stateful_condition_do_log(condition);  \
+ *        logging_internal_stateful_condition_do_log;                  \
+ *        logging_internal_stateful_condition_do_log = false)          \
+ *     for (static ::tsl::torch_xla::internal::Log##kind##State \
+ *              logging_internal_stateful_condition_state;             \
+ *          logging_internal_stateful_condition_do_log &&              \
+ *          logging_internal_stateful_condition_state.ShouldLog(arg);  \
+ *          logging_internal_stateful_condition_do_log = false)        \
+ *       for (const uint32_t COUNTER ABSL_ATTRIBUTE_UNUSED =           \
+ *                logging_internal_stateful_condition_state.counter(); \
+ *            logging_internal_stateful_condition_do_log;              \
+ *            logging_internal_stateful_condition_do_log = false)
+ *
+ * // An instance of `LOG_EVERY_N` increments a hidden zero-initialized counter
+ * // every time execution passes through it and logs the specified message when
+ * // the counter's value is a multiple of `n`, doing nothing otherwise.  Each
+ * // instance has its own counter.  The counter's value can be logged by
+ * streaming
+ * // the symbol `COUNTER`.  `LOG_EVERY_N` is thread-safe.
+ * // Example:
+ * //
+ * //   for (const auto& user : all_users) {
+ * //     LOG_EVERY_N(INFO, 1000) << "Processing user #" << COUNTER;
+ * //     ProcessUser(user);
+ * //   }
+ * #define LOG_EVERY_N(severity, n)                       \
+ *   LOGGING_INTERNAL_STATEFUL_CONDITION(EveryN, true, n) \
+ *   LOG(severity)
+ * // `LOG_FIRST_N` behaves like `LOG_EVERY_N` except that the specified message
+ * is
+ * // logged when the counter's value is less than `n`.  `LOG_FIRST_N` is
+ * // thread-safe.
+ * #define LOG_FIRST_N(severity, n)                       \
+ *   LOGGING_INTERNAL_STATEFUL_CONDITION(FirstN, true, n) \
+ *   LOG(severity)
+ * // `LOG_EVERY_POW_2` behaves like `LOG_EVERY_N` except that the specified
+ * // message is logged when the counter's value is a power of 2.
+ * // `LOG_EVERY_POW_2` is thread-safe.
+ * #define LOG_EVERY_POW_2(severity)                         \
+ *   LOGGING_INTERNAL_STATEFUL_CONDITION(EveryPow2, true, 0) \
+ *   LOG(severity)
+ * // An instance of `LOG_EVERY_N_SEC` uses a hidden state variable to log the
+ * // specified message at most once every `n_seconds`.  A hidden counter of
+ * // executions (whether a message is logged or not) is also maintained and can
+ * be
+ * // logged by streaming the symbol `COUNTER`.  `LOG_EVERY_N_SEC` is
+ * thread-safe.
+ * // Example:
+ * //
+ * //   LOG_EVERY_N_SEC(INFO, 2.5) << "Got " << COUNTER << " cookies so far";
+ * #define LOG_EVERY_N_SEC(severity, n_seconds)                      \
+ *   LOGGING_INTERNAL_STATEFUL_CONDITION(EveryNSec, true, n_seconds) \
+ *   LOG(severity)
+ *
+ * // CHECK dies with a fatal error if condition is not true.  It is *not*
+ * // controlled by NDEBUG, so the check will be executed regardless of
+ * // compilation mode.  Therefore, it is safe to do things like:
+ * //    CHECK(fp->Write(x) == 4)
+ * #define CHECK(condition)              \
+ *   if (TF_PREDICT_FALSE(!(condition))) \
+ *   LOG(FATAL) << "Check failed: " #condition " "
+ *
+ */
+
+// Function is overloaded for integral types to allow static const
+// integrals declared in classes and not defined to be used as arguments to
+// CHECK* macros. It's not encouraged though.
+template <typename T>
+inline const T& GetReferenceableValue(const T& t) {
+  return t;
+}
+inline char GetReferenceableValue(char t) { return t; }
+inline unsigned char GetReferenceableValue(unsigned char t) { return t; }
+inline signed char GetReferenceableValue(signed char t) { return t; }
+inline int16 GetReferenceableValue(int16_t t) { return t; }
+inline uint16 GetReferenceableValue(uint16 t) { return t; }
+inline int GetReferenceableValue(int t) { return t; }
+inline unsigned int GetReferenceableValue(unsigned int t) { return t; }
+inline int64_t GetReferenceableValue(int64_t t) { return t; }
+inline uint64 GetReferenceableValue(uint64 t) { return t; }
+
+// This formats a value for a failing CHECK_XX statement.  Ordinarily,
+// it uses the definition for operator<<, with a few special cases below.
+template <typename T>
+inline void MakeCheckOpValueString(std::ostream* os, const T& v) {
+  (*os) << v;
+}
+
+// Overrides for char types provide readable values for unprintable
+// characters.
+template <>
+void MakeCheckOpValueString(std::ostream* os, const char& v);
+template <>
+void MakeCheckOpValueString(std::ostream* os, const signed char& v);
+template <>
+void MakeCheckOpValueString(std::ostream* os, const unsigned char& v);
+
+#if LANG_CXX11
+// We need an explicit specialization for std::nullptr_t.
+template <>
+void MakeCheckOpValueString(std::ostream* os, const std::nullptr_t& v);
+#endif
+
+// A container for a string pointer which can be evaluated to a bool -
+// true iff the pointer is non-NULL.
+struct CheckOpString {
+  explicit CheckOpString(string* str) : str_(str) {}
+  // No destructor: if str_ is non-NULL, we're about to LOG(FATAL),
+  // so there's no point in cleaning up str_.
+  explicit operator bool() const { return TF_PREDICT_FALSE(str_ != nullptr); }
+  string* str_;
+};
+
+// Build the error message string. Specify no inlining for code size.
+template <typename T1, typename T2>
+string* MakeCheckOpString(const T1& v1, const T2& v2,
+                          const char* exprtext) ABSL_ATTRIBUTE_NOINLINE;
+
+// A helper class for formatting "expr (V1 vs. V2)" in a CHECK_XX
+// statement.  See MakeCheckOpString for sample usage.  Other
+// approaches were considered: use of a template method (e.g.,
+// base::BuildCheckOpString(exprtext, base::Print<T1>, &v1,
+// base::Print<T2>, &v2), however this approach has complications
+// related to volatile arguments and function-pointer arguments).
+class CheckOpMessageBuilder {
+ public:
+  // Inserts "exprtext" and " (" to the stream.
+  explicit CheckOpMessageBuilder(const char* exprtext);
+  // Deletes "stream_".
+  ~CheckOpMessageBuilder();
+  // For inserting the first variable.
+  std::ostream* ForVar1() { return stream_; }
+  // For inserting the second variable (adds an intermediate " vs. ").
+  std::ostream* ForVar2();
+  // Get the result (inserts the closing ")").
+  string* NewString();
+
+ private:
+  std::ostringstream* stream_;
+};
+
+template <typename T1, typename T2>
+string* MakeCheckOpString(const T1& v1, const T2& v2, const char* exprtext) {
+  CheckOpMessageBuilder comb(exprtext);
+  MakeCheckOpValueString(comb.ForVar1(), v1);
+  MakeCheckOpValueString(comb.ForVar2(), v2);
+  return comb.NewString();
+}
+
+// Helper functions for CHECK_OP macro.
+// We use the full name Check_EQ, Check_NE, etc. in case the file including
+// absl/log/log.h provides its own #defines for the simpler names EQ, NE, etc.
+// This happens if, for example, those are used as token names in a
+// yacc grammar.
+// The (int, int) overload works around the issue that the compiler
+// will not instantiate the template version of the function on values of
+// unnamed enum type - see comment below.
+#define TF_DEFINE_CHECK_OP_IMPL(name, op)                                     \
+  template <typename T1, typename T2>                                         \
+  inline string* name##Impl(const T1& v1, const T2& v2,                       \
+                            const char* exprtext) {                           \
+    if (TF_PREDICT_TRUE(v1 op v2))                                            \
+      return NULL;                                                            \
+    else                                                                      \
+      return ::tsl::torch_xla::internal::MakeCheckOpString(v1, v2, exprtext); \
+  }                                                                           \
+  inline string* name##Impl(int v1, int v2, const char* exprtext) {           \
+    return name##Impl<int, int>(v1, v2, exprtext);                            \
+  }
+
+// The (size_t, int) and (int, size_t) specialization are to handle unsigned
+// comparison errors while still being thorough with the comparison.
+
+TF_DEFINE_CHECK_OP_IMPL(Check_EQ, ==)
+// Compilation error with CHECK_EQ(NULL, x)?
+// Use CHECK(x == NULL) instead.
+
+inline string* Check_EQImpl(int v1, size_t v2, const char* exprtext) {
+  if (TF_PREDICT_FALSE(v1 < 0))
+    ::tsl::torch_xla::internal::MakeCheckOpString(v1, v2, exprtext);
+
+  return Check_EQImpl(size_t(v1), v2, exprtext);
+}
+
+inline string* Check_EQImpl(size_t v1, int v2, const char* exprtext) {
+  return Check_EQImpl(v2, v1, exprtext);
+}
+
+TF_DEFINE_CHECK_OP_IMPL(Check_NE, !=)
+
+inline string* Check_NEImpl(int v1, size_t v2, const char* exprtext) {
+  if (v1 < 0) return NULL;
+
+  return Check_NEImpl(size_t(v1), v2, exprtext);
+}
+
+inline string* Check_NEImpl(size_t v1, int v2, const char* exprtext) {
+  return Check_NEImpl(v2, v1, exprtext);
+}
+
+TF_DEFINE_CHECK_OP_IMPL(Check_LE, <=)
+
+inline string* Check_LEImpl(int v1, size_t v2, const char* exprtext) {
+  if (v1 <= 0) return NULL;
+
+  return Check_LEImpl(size_t(v1), v2, exprtext);
+}
+
+inline string* Check_LEImpl(size_t v1, int v2, const char* exprtext) {
+  if (TF_PREDICT_FALSE(v2 < 0))
+    return ::tsl::torch_xla::internal::MakeCheckOpString(v1, v2, exprtext);
+  return Check_LEImpl(v1, size_t(v2), exprtext);
+}
+
+TF_DEFINE_CHECK_OP_IMPL(Check_LT, <)
+
+inline string* Check_LTImpl(int v1, size_t v2, const char* exprtext) {
+  if (v1 < 0) return NULL;
+
+  return Check_LTImpl(size_t(v1), v2, exprtext);
+}
+
+inline string* Check_LTImpl(size_t v1, int v2, const char* exprtext) {
+  if (v2 < 0)
+    return ::tsl::torch_xla::internal::MakeCheckOpString(v1, v2, exprtext);
+  return Check_LTImpl(v1, size_t(v2), exprtext);
+}
+
+// Implement GE,GT in terms of LE,LT
+template <typename T1, typename T2>
+inline string* Check_GEImpl(const T1& v1, const T2& v2, const char* exprtext) {
+  return Check_LEImpl(v2, v1, exprtext);
+}
+
+template <typename T1, typename T2>
+inline string* Check_GTImpl(const T1& v1, const T2& v2, const char* exprtext) {
+  return Check_LTImpl(v2, v1, exprtext);
+}
+
+#undef TF_DEFINE_CHECK_OP_IMPL
+
+/*
+ * Avoiding duplicated macro.
+ *
+ * // In optimized mode, use CheckOpString to hint to compiler that
+ * // the while condition is unlikely.
+ * #define CHECK_OP_LOG(name, op, val1, val2) \
+ *   while (::tsl::torch_xla::internal::CheckOpString
+ * _result{::tsl::torch_xla::internal::name##Impl(   \
+ *       ::tsl::torch_xla::internal::GetReferenceableValue(val1), \
+ *       ::tsl::torch_xla::internal::GetReferenceableValue(val2), #val1 " " #op
+ * " " #val2)}) \
+ *   ::tsl::torch_xla::internal::LogMessageFatal(__FILE__, __LINE__) <<
+ * *(_result.str_)
+ *
+ * #define CHECK_OP(name, op, val1, val2) CHECK_OP_LOG(name, op, val1, val2)
+ *
+ * // CHECK_EQ/NE/...
+ * #define CHECK_EQ(val1, val2) CHECK_OP(Check_EQ, ==, val1, val2)
+ * #define CHECK_NE(val1, val2) CHECK_OP(Check_NE, !=, val1, val2)
+ * #define CHECK_LE(val1, val2) CHECK_OP(Check_LE, <=, val1, val2)
+ * #define CHECK_LT(val1, val2) CHECK_OP(Check_LT, <, val1, val2)
+ * #define CHECK_GE(val1, val2) CHECK_OP(Check_GE, >=, val1, val2)
+ * #define CHECK_GT(val1, val2) CHECK_OP(Check_GT, >, val1, val2)
+ * #define CHECK_NOTNULL(val)                          \
+ *   ::tsl::torch_xla::internal::CheckNotNull(__FILE__, __LINE__, \
+ *                                 "'" #val "' Must be non NULL", (val))
+ *
+ * #ifndef NDEBUG
+ * // DCHECK_EQ/NE/...
+ * #define DCHECK(condition) CHECK(condition)
+ * #define DCHECK_EQ(val1, val2) CHECK_EQ(val1, val2)
+ * #define DCHECK_NE(val1, val2) CHECK_NE(val1, val2)
+ * #define DCHECK_LE(val1, val2) CHECK_LE(val1, val2)
+ * #define DCHECK_LT(val1, val2) CHECK_LT(val1, val2)
+ * #define DCHECK_GE(val1, val2) CHECK_GE(val1, val2)
+ * #define DCHECK_GT(val1, val2) CHECK_GT(val1, val2)
+ *
+ * #else
+ *
+ * #define DCHECK(condition) \
+ *   while (false && (condition)) LOG(FATAL)
+ *
+ * // NDEBUG is defined, so DCHECK_EQ(x, y) and so on do nothing.
+ * // However, we still want the compiler to parse x and y, because
+ * // we don't want to lose potentially useful errors and warnings.
+ * // _DCHECK_NOP is a helper, and should not be used outside of this file.
+ * #define _TF_DCHECK_NOP(x, y) \
+ *   while (false && ((void)(x), (void)(y), 0)) LOG(FATAL)
+ *
+ * #define DCHECK_EQ(x, y) _TF_DCHECK_NOP(x, y)
+ * #define DCHECK_NE(x, y) _TF_DCHECK_NOP(x, y)
+ * #define DCHECK_LE(x, y) _TF_DCHECK_NOP(x, y)
+ * #define DCHECK_LT(x, y) _TF_DCHECK_NOP(x, y)
+ * #define DCHECK_GE(x, y) _TF_DCHECK_NOP(x, y)
+ * #define DCHECK_GT(x, y) _TF_DCHECK_NOP(x, y)
+ *
+ * #endif
+ *
+ * // These are for when you don't want a CHECK failure to print a verbose
+ * // stack trace.  The implementation of CHECK* in this file already doesn't.
+ * #define QCHECK(condition) CHECK(condition)
+ * #define QCHECK_EQ(x, y) CHECK_EQ(x, y)
+ * #define QCHECK_NE(x, y) CHECK_NE(x, y)
+ * #define QCHECK_LE(x, y) CHECK_LE(x, y)
+ * #define QCHECK_LT(x, y) CHECK_LT(x, y)
+ * #define QCHECK_GE(x, y) CHECK_GE(x, y)
+ * #define QCHECK_GT(x, y) CHECK_GT(x, y)
+ *
+ */
+
+template <typename T>
+T&& CheckNotNull(const char* file, int line, const char* exprtext, T&& t) {
+  if (t == nullptr) {
+    LogMessageFatal(file, line) << string(exprtext);
+  }
+  return std::forward<T>(t);
+}
+
+absl::LogSeverityAtLeast MinLogLevelFromEnv();
+
+int MaxVLogLevelFromEnv();
+
+}  // namespace internal
+
+// LogSink support adapted from absl/log/log.h
+//
+// `LogSink` is an interface which can be extended to intercept and process
+// all log messages. LogSink implementations must be thread-safe. A single
+// instance will be called from whichever thread is performing a logging
+// operation.
+class TFLogEntry {
+ public:
+  explicit TFLogEntry(absl::LogSeverity severity, absl::string_view message)
+      : severity_(severity), message_(message) {}
+
+  explicit TFLogEntry(absl::LogSeverity severity, absl::string_view fname,
+                      int line, absl::string_view message)
+      : severity_(severity), fname_(fname), line_(line), message_(message) {}
+
+  absl::LogSeverity log_severity() const { return severity_; }
+  std::string FName() const { return fname_; }
+  int Line() const { return line_; }
+  std::string ToString() const { return message_; }
+  absl::string_view text_message() const { return message_; }
+
+  // Returning similar result as `text_message` as there is no prefix in this
+  // implementation.
+  absl::string_view text_message_with_prefix() const { return message_; }
+
+ private:
+  const absl::LogSeverity severity_;
+  const std::string fname_;
+  int line_ = -1;
+  const std::string message_;
+};
+
+class TFLogSink {
+ public:
+  virtual ~TFLogSink() = default;
+
+  // `Send` is called synchronously during the log statement.  The logging
+  // module guarantees not to call `Send` concurrently on the same log sink.
+  // Implementations should be careful not to call`LOG` or `CHECK` or take
+  // any locks that might be held by the `LOG` caller, to avoid deadlock.
+  //
+  // `e` is guaranteed to remain valid until the subsequent call to
+  // `WaitTillSent` completes, so implementations may store a pointer to or
+  // copy of `e` (e.g. in a thread local variable) for use in `WaitTillSent`.
+  virtual void Send(const TFLogEntry& entry) = 0;
+
+  // `WaitTillSent` blocks the calling thread (the thread that generated a log
+  // message) until the sink has finished processing the log message.
+  // `WaitTillSent` is called once per log message, following the call to
+  // `Send`.  This may be useful when log messages are buffered or processed
+  // asynchronously by an expensive log sink.
+  // The default implementation returns immediately.  Like `Send`,
+  // implementations should be careful not to call `LOG` or `CHECK or take any
+  // locks that might be held by the `LOG` caller, to avoid deadlock.
+  virtual void WaitTillSent() {}
+};
+
+// This is the default log sink. This log sink is used if there are no other
+// log sinks registered. To disable the default log sink, set the
+// "no_default_logger" Bazel config setting to true or define a
+// NO_DEFAULT_LOGGER preprocessor symbol. This log sink will always log to
+// stderr.
+class TFDefaultLogSink : public TFLogSink {
+ public:
+  void Send(const TFLogEntry& entry) override;
+};
+
+// Add or remove a `LogSink` as a consumer of logging data.  Thread-safe.
+void TFAddLogSink(TFLogSink* sink);
+void TFRemoveLogSink(TFLogSink* sink);
+
+// Get all the log sinks.  Thread-safe.
+std::vector<TFLogSink*> TFGetLogSinks();
+
+// Change verbose level of pre-defined files if envorionment
+// variable `env_var` is defined. This is currently a no op.
+void UpdateLogVerbosityIfDefined(const char* env_var);
+
+}  // namespace torch_xla
+}  // namespace tsl
+
+#endif  // XLA_TORCH_XLA_CSRC_RUNTIME_TSL_PLATFORM_LOGGING_H_

--- a/torch_xla/csrc/runtime/xla_coordinator.cpp
+++ b/torch_xla/csrc/runtime/xla_coordinator.cpp
@@ -20,9 +20,14 @@ absl::Status XlaCoordinator::Initialize(int global_rank, int world_size,
     // https://github.com/openxla/xla/blob/4b88636002bc5834d7fe3f862997c66a490987bc/xla/pjrt/distributed/client.h#L63-L72.
     int heartbeat_interval_sec =
         sys_util::GetEnvInt(env::kEnvDistSvcHeartbeatIntervalInSec, 10);
-    service_options.heartbeat_interval = absl::Seconds(heartbeat_interval_sec);
-    service_options.max_missing_heartbeats =
+    int max_missing_heartbeats =
         sys_util::GetEnvInt(env::kEnvDistSvcMaxMissingHeartbeats, 10);
+    // The service concludes a client has vanished once it hasn't received any
+    // heartbeats within this timeout. The coordination service now takes the
+    // combined timeout directly instead of a heartbeat interval and a maximum
+    // number of missed heartbeats.
+    service_options.heartbeat_timeout =
+        absl::Seconds(heartbeat_interval_sec) * max_missing_heartbeats;
     int shutdown_timeout =
         sys_util::GetEnvInt(env::kEnvDistSvcShutdownTimeoutInMin, 5);
     service_options.shutdown_timeout = absl::Minutes(shutdown_timeout);
@@ -74,7 +79,7 @@ std::shared_ptr<xla::DistributedRuntimeClient> XlaCoordinator::GetClient() {
 
 void XlaCoordinator::ActivatePreemptionSyncManager() {
   if (preemption_sync_manager_ == nullptr) {
-    preemption_sync_manager_ = std::move(tsl::CreatePreemptionSyncManager());
+    preemption_sync_manager_ = std::move(xla::CreatePreemptionSyncManager());
     auto client = dist_runtime_client_->GetCoordinationServiceAgent();
     XLA_CHECK(client.ok()) << "Failed to retrieve the CoodinationServiceAgent";
     auto status = preemption_sync_manager_->Initialize(client.value());

--- a/torch_xla/csrc/runtime/xla_coordinator.cpp
+++ b/torch_xla/csrc/runtime/xla_coordinator.cpp
@@ -22,10 +22,6 @@ absl::Status XlaCoordinator::Initialize(int global_rank, int world_size,
         sys_util::GetEnvInt(env::kEnvDistSvcHeartbeatIntervalInSec, 10);
     int max_missing_heartbeats =
         sys_util::GetEnvInt(env::kEnvDistSvcMaxMissingHeartbeats, 10);
-    // The service concludes a client has vanished once it hasn't received any
-    // heartbeats within this timeout. The coordination service now takes the
-    // combined timeout directly instead of a heartbeat interval and a maximum
-    // number of missed heartbeats.
     service_options.heartbeat_timeout =
         absl::Seconds(heartbeat_interval_sec) * max_missing_heartbeats;
     int shutdown_timeout =

--- a/torch_xla/csrc/runtime/xla_coordinator.h
+++ b/torch_xla/csrc/runtime/xla_coordinator.h
@@ -5,7 +5,7 @@
 
 #include "absl/base/nullability.h"
 #include "xla/pjrt/distributed/distributed.h"
-#include "xla/tsl/distributed_runtime/preemption/preemption_sync_manager.h"
+#include "xla/pjrt/distributed/preemption/preemption_sync_manager.h"
 
 namespace torch_xla {
 namespace runtime {
@@ -69,7 +69,7 @@ class XlaCoordinator {
 
   std::unique_ptr<xla::DistributedRuntimeService> dist_runtime_service_;
   std::shared_ptr<xla::DistributedRuntimeClient> dist_runtime_client_;
-  std::unique_ptr<tsl::PreemptionSyncManager> preemption_sync_manager_;
+  std::unique_ptr<xla::PreemptionSyncManager> preemption_sync_manager_;
 };
 
 }  // namespace runtime

--- a/torch_xla/csrc/status.cpp
+++ b/torch_xla/csrc/status.cpp
@@ -3,6 +3,7 @@
 #include <torch/csrc/utils/cpp_stacktraces.h>
 
 #include "absl/log/absl_check.h"
+#include "absl/strings/str_cat.h"
 
 namespace torch_xla {
 


### PR DESCRIPTION
## Summary

Uplift PyTorch/XLA to **jax/jaxlib 0.11.0** and **OpenXLA `131bf41acb4650e4391a640c3f1859c1c86ad74b`** (the revision jaxlib 0.11.0 pins, committed 2026-07-16).

Beyond the version bump, this rebases the OpenXLA patch set, migrates the WORKSPACE to the hermetic `rules_ml_toolchain` setup that this XLA revision requires, and adapts the C++ runtime to the XLA API drift.

## Review order

The commits form a logical progression:

1. **Pin + patches** — bump jax/jaxlib and `xla_hash`; drop the now-obsolete GPU patches and rebase `count_down` onto its new location.
2. **WORKSPACE / toolchain** — reorder init so `@rules_ml_toolchain` is defined before the hermetic Python setup that depends on it; add hermetic CUDA/NCCL/nvSHMEM and C++ toolchain init; load `compile_pip_requirements` from `@rules_python` (the per-version hub repo replaced `@python`).
3. **codegen bootstrap** — use rules_python's `py_binary` for the generator: the native rule leaves the bootstrap template's `%interpreter_args%` placeholder unsubstituted and crashes with a SyntaxError.
4. **Logging** — port the vendored TSL logging shim to Abseil (OpenXLA removed its internal logging in openxla/xla#29477).
5. **C++ API drift** — `xla::PjRtFuture`→`xla::Future`, `Shape::FromProto`, ifrt topology/array API changes, `GetXlaPjrtCpuClient` + `CpuClientOptions`, preemption `tsl::`→`xla::`, opaque `PJRT_Error` handling, `[[nodiscard]]` `MessageToJsonString`.
6. **bazel strict include validation** — the hermetic clang rejects headers that are reached but undeclared: declare torch's in-tree `c10/`, `caffe2/`, `torch/csrc/` headers (hardlinked to `torch/include/`, so inode-safe) and Debian's multiarch `pyconfig.h`; point runtime targets at the moved XLA targets (`preemption_sync_manager`, `pjrt_future`).

## Verification

- `bazel build //:_XLAC.so` links cleanly — 0 undeclared inclusions, 0 compile errors.
- The full wheel builds and installs alongside `jax==0.11.0` / `jaxlib==0.11.0` with no dependency conflict (the previous hard `jax==0.7.1` pin is gone).
- `import torch_xla` works with jax 0.11 present.

Authored with Claude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
