### PR TITLE
bazel: fix multiarch pyconfig genrule for pyenv release build

### DIFF
--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -2,10 +2,13 @@
 # @local_config_python is only a wrapper that includes the real
 # <x86_64-linux-gnu/python3.12/pyconfig.h>, which is never copied and is thus
 # undeclared under strict include validation. Provide the real header here.
+# Non-Debian toolchains (e.g. the pyenv Python used by the release build) don't
+# split pyconfig.h and never include the multiarch path, so emit an empty,
+# never-included stub when the multiarch header is absent.
 genrule(
     name = "multiarch_pyconfig_h",
     outs = ["python_include/x86_64-linux-gnu/python3.12/pyconfig.h"],
-    cmd = "cp -f /usr/include/x86_64-linux-gnu/python3.12/pyconfig.h $@",
+    cmd = "cp -f /usr/include/x86_64-linux-gnu/python3.12/pyconfig.h $@ 2>/dev/null || touch $@",
 )
 
 cc_library(


### PR DESCRIPTION
The `multiarch_pyconfig` genrule copies Debian's split `/usr/include/x86_64-linux-gnu/python3.12/pyconfig.h`, which only exists under the system `python3.12-dev`. The `build_and_publish` release build uses a pyenv Python that doesn't split `pyconfig.h` (and never includes the multiarch path), so the copy failed and `_XLAC.so` didn't build — the wheel publish (run 31705610762) failed here. Falls back to an empty, never-included stub when the header is absent; the Debian/manual-build path is unchanged (verified locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)